### PR TITLE
Replacing file resolver with classpath resolver.

### DIFF
--- a/timer-log-xml/src/main/resources/application.properties
+++ b/timer-log-xml/src/main/resources/application.properties
@@ -30,4 +30,6 @@ camel.context.name = quarkus-camel-example-timer-log-xml
 #
 # Camel Main
 #
-camel.main.xml-routes = file:src/main/resources/routes/my-routes.xml
+#camel.main.xml-routes = file:src/main/resources/routes/my-routes.xml
+camel.main.xml-routes = classpath:routes/my-routes.xml
+quarkus.camel.native.resources.include-patterns = routes/*.xml 

--- a/timer-log-xml/src/main/resources/application.properties
+++ b/timer-log-xml/src/main/resources/application.properties
@@ -30,6 +30,6 @@ camel.context.name = quarkus-camel-example-timer-log-xml
 #
 # Camel Main
 #
-#camel.main.xml-routes = file:src/main/resources/routes/my-routes.xml
+# camel.main.xml-routes = file:src/main/resources/routes/my-routes.xml
 camel.main.xml-routes = classpath:routes/my-routes.xml
 quarkus.camel.native.resources.include-patterns = routes/*.xml 


### PR DESCRIPTION
Classpath resolver has couple of benefits first we can run native build from any location otherwise with file resolver it has to be run only from specific location only. Second with classpath resolved kubernetes or openshift based deployment will also run without errors.