### PR TITLE
Upgrade to Camel Quarkus 1.7.0

### DIFF
--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Observability</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-cdi/pom.xml
+++ b/timer-log-cdi/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log CDI</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
         <kotlin.version>1.4.20</kotlin.version>
 

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-spring/pom.xml
+++ b/timer-log-spring/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Spring</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-xml/pom.xml
+++ b/timer-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log XML</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <camel-quarkus.version>1.6.0</camel-quarkus.version>
+        <camel-quarkus.version>1.7.0</camel-quarkus.version>
         <quarkus.version>1.11.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Note that the `master` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-master` branch pointing at the current Camel Quarkus SNAPSHOT.