### PR TITLE
Remove redundant remove-unused-beans property

### DIFF
--- a/timer-log-cdi/src/main/resources/application.properties
+++ b/timer-log-cdi/src/main/resources/application.properties
@@ -20,10 +20,6 @@
 #
 quarkus.banner.enabled = false
 
-# camel look-up beans using BeanManager so we don't want
-# ArC to remove beans without injection points.
-quarkus.arc.remove-unused-beans = false
-
 #
 # Integration
 #


### PR DESCRIPTION
I can't remember the history around why `remove-unused-beans` was disabled. But, none of the beans produced in this example are candidates for removal.

* Class `Counter` is `@Inject`ed into the `RouteBuilder`
* The custom `LogComponent` producer method is annotated with `@Named`
