### PR TITLE
Use MP config instead of System.getProperty() in a test to simplify t…

### DIFF
--- a/file-bindy-ftp/src/main/resources/application.properties
+++ b/file-bindy-ftp/src/main/resources/application.properties
@@ -28,10 +28,10 @@ timer.delay = 10000
 csv.location = {{sys:java.io.tmpdir}}/books
 
 # FTP server location
-ftp.host = {{env:FTP_SERVER_SERVICE_HOST:localhost}}
-ftp.port = {{env:FTP_SERVER_SERVICE_PORT:2222}}
-ftp.username = {{env:FTP_USER:ftpuser}}
-ftp.password = {{env:FTP_PASSWORD:ftppassword}}
+ftp.host = ${FTP_SERVER_SERVICE_HOST:localhost}
+ftp.port = ${FTP_SERVER_SERVICE_PORT:2222}
+ftp.username = ${FTP_USER:ftpuser}
+ftp.password = ${FTP_PASSWORD:ftppassword}
 
 # Kubernetes
 

--- a/file-bindy-ftp/src/test/java/org/apache/camel/example/FileToFtpTest.java
+++ b/file-bindy-ftp/src/test/java/org/apache/camel/example/FileToFtpTest.java
@@ -25,6 +25,8 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
@@ -35,11 +37,14 @@ public class FileToFtpTest {
 
     @Test
     public void testFileToFtp() throws JSchException {
-        JSch jsch = new JSch();
-        jsch.setKnownHosts(System.getProperty("user.home") + "/.ssh/known_hosts");
 
-        Session session = jsch.getSession("ftpuser", System.getProperty("ftp.host"));
-        session.setPort(Integer.parseInt(System.getProperty("ftp.port")));
+        Config config = ConfigProvider.getConfig();
+
+        JSch jsch = new JSch();
+        jsch.setKnownHosts(config.getValue("user.home", String.class) + "/.ssh/known_hosts");
+
+        Session session = jsch.getSession("ftpuser", config.getValue("ftp.host", String.class));
+        session.setPort(Integer.parseInt(config.getValue("ftp.port", String.class)));
         session.setPassword("ftppassword");
         session.setConfig("StrictHostKeyChecking", "no");
         session.connect(5000);


### PR DESCRIPTION
…esting against manuanlly started services
