### PR TITLE
fix up TimerLogMainTest #2711

### DIFF
--- a/timer-log-main/src/test/java/org/acme/timer/TimerLogMainTest.java
+++ b/timer-log-main/src/test/java/org/acme/timer/TimerLogMainTest.java
@@ -74,7 +74,7 @@ public class TimerLogMainTest {
         try {
             int status = RestAssured.given()
                     .port(port)
-                    .get("/health")
+                    .get("/q/health")
                     .then()
                     .extract()
                     .statusCode();


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.