### PR TITLE
Use 2.1.0-SNAPSHOT as project version

### DIFF
--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-file-bindy-ftp</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: File Bindy FTP</name>
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-file-log-xml</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: File To Log XML DSL</name>
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-health</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Health</name>
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-http-log</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: HTTP Log</name>
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-kafka</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Kafka</name>
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-observability</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Observability</name>
     <description>Camel Quarkus Example :: Observability</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-rest-json</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Rest Json</name>
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-cdi/pom.xml
+++ b/timer-log-cdi/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-timer-log-cdi</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log CDI</name>
     <description>Camel Quarkus Example :: Timer to Log CDI</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-timer-log-kotlin</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Kotlin</name>
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
         <kotlin.version>1.4.32</kotlin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-timer-log-main</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Main</name>
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-spring/pom.xml
+++ b/timer-log-spring/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-timer-log-spring</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Spring</name>
     <description>Camel Quarkus Example :: Timer to Log Spring</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-xml/pom.xml
+++ b/timer-log-xml/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-timer-log-xml</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log XML</name>
     <description>Camel Quarkus Example :: Timer to Log XML</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -22,14 +22,14 @@
 
     <artifactId>camel-quarkus-examples-timer-log</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log</name>
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <camel-quarkus.version>2.0.0-SNAPSHOT</camel-quarkus.version>
-        <quarkus.version>2.0.0.CR3</quarkus.version>
+        <camel-quarkus.version>2.1.0-SNAPSHOT</camel-quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.