### PR TITLE
Bump Strimzi kafka-oauth-client version from Quarkus bom

### DIFF
--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -27,7 +27,7 @@
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -50,7 +50,6 @@
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <mycila-license.version>3.0</mycila-license.version>
-        <kafka-oauth-client.version>0.7.2</kafka-oauth-client.version>
     </properties>
 
     <dependencyManagement>
@@ -69,11 +68,6 @@
                 <version>${camel-quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.strimzi</groupId>
-                <artifactId>kafka-oauth-client</artifactId>
-                <version>${kafka-oauth-client.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
 
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-cdi/pom.xml
+++ b/timer-log-cdi/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log CDI</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->

--- a/timer-log-spring/pom.xml
+++ b/timer-log-spring/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Spring</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-xml/pom.xml
+++ b/timer-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log XML</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.