### PR TITLE
Fix link notation in Kafka readme

### DIFF
--- a/kafka/README.adoc
+++ b/kafka/README.adoc
@@ -12,9 +12,9 @@ and other general information.
 The example application requires a Kafka instance.
 
 You do not need to provide the Kafka instance yourself
-as long as you play with the example code in dev mode (a.k.a. `mvn quarkus:dev` - read more [here](https://quarkus.io/guides/getting-started#development-mode))
+as long as you play with the example code in dev mode (a.k.a. `mvn quarkus:dev` - read more https://quarkus.io/guides/getting-started#development-mode[here]
 or as long as you only run the supplied tests (`mvn test`).
-In those situations, Quarkus tooling starts a Redpanda image for you via [Quarkus Dev Services](https://quarkus.io/guides/kafka-dev-services)
+In those situations, Quarkus tooling starts a Redpanda image for you via https://quarkus.io/guides/kafka-dev-services[Quarkus Dev Services]
 and it also configures the application so that you do not need touch anything in `application.properties`.
 
 == Start in Development mode


### PR DESCRIPTION
A Markdown notation was used in an AsciiDoc file

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.