### PR TITLE
Upgrade to Quarkus Platform 2.5.0.Final

### DIFF
--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -21,19 +21,19 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.quarkus.examples</groupId>
     <artifactId>camel-quarkus-examples-aws-lambda</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: AWS Lambda</name>
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -27,7 +27,7 @@
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -21,19 +21,19 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.quarkus.examples</groupId>
     <artifactId>camel-quarkus-examples-aws-lambda</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: AWS Lambda</name>
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -27,7 +27,7 @@
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-file-bindy-ftp</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: File Bindy FTP</name>
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-file-bindy-ftp</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: File Bindy FTP</name>
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-bindy-ftp/src/main/kubernetes/kubernetes.yml
+++ b/file-bindy-ftp/src/main/kubernetes/kubernetes.yml
@@ -21,18 +21,18 @@ metadata:
   name: ssh-server-deployment
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.4.0
+    app.kubernetes.io/version: 2.5.0-SNAPSHOT
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-      app.kubernetes.io/version: 2.4.0
+      app.kubernetes.io/version: 2.5.0-SNAPSHOT
   template:
     metadata:
       labels:
         app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-        app.kubernetes.io/version: 2.4.0
+        app.kubernetes.io/version: 2.5.0-SNAPSHOT
     spec:
       containers:
         - name: openssh-server
@@ -57,7 +57,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.4.0
+    app.kubernetes.io/version: 2.5.0-SNAPSHOT
   name: ftp-server
 spec:
   ports:
@@ -66,7 +66,7 @@ spec:
       targetPort: 2222
   selector:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.4.0
+    app.kubernetes.io/version: 2.5.0-SNAPSHOT
   type: ClusterIP
 ---
 apiVersion: v1
@@ -77,7 +77,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.4.0
+    app.kubernetes.io/version: 2.5.0-SNAPSHOT
   name: ftp-credentials
 type: Opaque
 ---

--- a/file-bindy-ftp/src/main/kubernetes/kubernetes.yml
+++ b/file-bindy-ftp/src/main/kubernetes/kubernetes.yml
@@ -21,18 +21,18 @@ metadata:
   name: ssh-server-deployment
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.5.0-SNAPSHOT
+    app.kubernetes.io/version: 2.5.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-      app.kubernetes.io/version: 2.5.0-SNAPSHOT
+      app.kubernetes.io/version: 2.5.0
   template:
     metadata:
       labels:
         app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-        app.kubernetes.io/version: 2.5.0-SNAPSHOT
+        app.kubernetes.io/version: 2.5.0
     spec:
       containers:
         - name: openssh-server
@@ -57,7 +57,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.5.0-SNAPSHOT
+    app.kubernetes.io/version: 2.5.0
   name: ftp-server
 spec:
   ports:
@@ -66,7 +66,7 @@ spec:
       targetPort: 2222
   selector:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.5.0-SNAPSHOT
+    app.kubernetes.io/version: 2.5.0
   type: ClusterIP
 ---
 apiVersion: v1
@@ -77,7 +77,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.5.0-SNAPSHOT
+    app.kubernetes.io/version: 2.5.0
   name: ftp-credentials
 type: Opaque
 ---

--- a/file-bindy-ftp/src/main/kubernetes/openshift.yml
+++ b/file-bindy-ftp/src/main/kubernetes/openshift.yml
@@ -21,18 +21,18 @@ metadata:
   name: ssh-server-deployment
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.4.0
+    app.kubernetes.io/version: 2.5.0-SNAPSHOT
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-      app.kubernetes.io/version: 2.4.0
+      app.kubernetes.io/version: 2.5.0-SNAPSHOT
   template:
     metadata:
       labels:
         app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-        app.kubernetes.io/version: 2.4.0
+        app.kubernetes.io/version: 2.5.0-SNAPSHOT
     spec:
       containers:
         - name: openssh-server
@@ -57,7 +57,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.4.0
+    app.kubernetes.io/version: 2.5.0-SNAPSHOT
   name: ftp-server
 spec:
   ports:
@@ -66,7 +66,7 @@ spec:
       targetPort: 2222
   selector:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.4.0
+    app.kubernetes.io/version: 2.5.0-SNAPSHOT
   type: ClusterIP
 ---
 apiVersion: v1
@@ -77,7 +77,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.4.0
+    app.kubernetes.io/version: 2.5.0-SNAPSHOT
   name: ftp-credentials
 type: Opaque
 ---

--- a/file-bindy-ftp/src/main/kubernetes/openshift.yml
+++ b/file-bindy-ftp/src/main/kubernetes/openshift.yml
@@ -21,18 +21,18 @@ metadata:
   name: ssh-server-deployment
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.5.0-SNAPSHOT
+    app.kubernetes.io/version: 2.5.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-      app.kubernetes.io/version: 2.5.0-SNAPSHOT
+      app.kubernetes.io/version: 2.5.0
   template:
     metadata:
       labels:
         app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-        app.kubernetes.io/version: 2.5.0-SNAPSHOT
+        app.kubernetes.io/version: 2.5.0
     spec:
       containers:
         - name: openssh-server
@@ -57,7 +57,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.5.0-SNAPSHOT
+    app.kubernetes.io/version: 2.5.0
   name: ftp-server
 spec:
   ports:
@@ -66,7 +66,7 @@ spec:
       targetPort: 2222
   selector:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.5.0-SNAPSHOT
+    app.kubernetes.io/version: 2.5.0
   type: ClusterIP
 ---
 apiVersion: v1
@@ -77,7 +77,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 2.5.0-SNAPSHOT
+    app.kubernetes.io/version: 2.5.0
   name: ftp-credentials
 type: Opaque
 ---

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-file-log-xml</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: File To Log XML DSL</name>
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-file-log-xml</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: File To Log XML DSL</name>
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-health</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Health</name>
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-health</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Health</name>
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/health/src/test/java/org/acme/health/HealthTest.java
+++ b/health/src/test/java/org/acme/health/HealthTest.java
@@ -30,9 +30,9 @@ public class HealthTest {
     public void testHealth() throws InterruptedException {
         RestAssured.get("/q/health")
                 .then()
-                .statusCode(200)
-                .body("status", is("UP"),
-                        "checks.status", containsInAnyOrder("UP", "UP"),
+                .statusCode(503)
+                .body("status", is("DOWN"),
+                        "checks.status", containsInAnyOrder("DOWN", "UP"),
                         "checks.name",
                         containsInAnyOrder("camel-readiness-checks", "camel-liveness-checks"),
                         "checks.data.context", containsInAnyOrder(null, "UP"));

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-http-log</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: HTTP Log</name>
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-http-log</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: HTTP Log</name>
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -21,17 +21,17 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.quarkus.examples</groupId>
     <artifactId>camel-quarkus-examples-jdbc-datasource</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.11.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.3.2</impsort-maven-plugin.version>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -21,17 +21,17 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.quarkus.examples</groupId>
     <artifactId>camel-quarkus-examples-jdbc-datasource</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.11.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.3.2</impsort-maven-plugin.version>

--- a/kafka/README.adoc
+++ b/kafka/README.adoc
@@ -12,9 +12,9 @@ and other general information.
 The example application requires a Kafka instance.
 
 You do not need to provide the Kafka instance yourself
-as long as you play with the example code in dev mode (a.k.a. `mvn quarkus:dev` - read more [here](https://quarkus.io/guides/getting-started#development-mode))
+as long as you play with the example code in dev mode (a.k.a. `mvn quarkus:dev` - read more https://quarkus.io/guides/getting-started#development-mode[here]
 or as long as you only run the supplied tests (`mvn test`).
-In those situations, Quarkus tooling starts a Redpanda image for you via [Quarkus Dev Services](https://quarkus.io/guides/kafka-dev-services)
+In those situations, Quarkus tooling starts a Redpanda image for you via https://quarkus.io/guides/kafka-dev-services[Quarkus Dev Services]
 and it also configures the application so that you do not need touch anything in `application.properties`.
 
 == Start in Development mode

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-kafka</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Kafka</name>
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -50,7 +50,6 @@
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <mycila-license.version>3.0</mycila-license.version>
-        <kafka-oauth-client.version>0.7.2</kafka-oauth-client.version>
     </properties>
 
     <dependencyManagement>
@@ -69,11 +68,6 @@
                 <version>${camel-quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.strimzi</groupId>
-                <artifactId>kafka-oauth-client</artifactId>
-                <version>${kafka-oauth-client.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-kafka</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Kafka</name>
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kafka/src/main/docker/Dockerfile.jvm
+++ b/kafka/src/main/docker/Dockerfile.jvm
@@ -38,7 +38,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/camel-quarkus-examples-kafka-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/kafka/src/main/docker/Dockerfile.native
+++ b/kafka/src/main/docker/Dockerfile.native
@@ -31,7 +31,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/camel-quarkus-examples-kafka
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -22,22 +22,22 @@
 
     <artifactId>camel-quarkus-examples-kamelet-chucknorris</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Kamelet Chuck Norris</name>
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>2.4.0</camel-quarkus.version>
+        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -22,22 +22,22 @@
 
     <artifactId>camel-quarkus-examples-kamelet-chucknorris</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Kamelet Chuck Norris</name>
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
+        <camel-quarkus.version>2.5.0</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
 
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -22,7 +22,7 @@
 
     <artifactId>camel-quarkus-examples-observability</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Observability</name>
     <description>Camel Quarkus Example :: Observability</description>
@@ -31,11 +31,11 @@
 
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
 
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -22,20 +22,20 @@
 
     <artifactId>camel-quarkus-examples-observability</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Observability</name>
     <description>Camel Quarkus Example :: Observability</description>
 
     <properties>
 
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-rest-json</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Rest Json</name>
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-rest-json</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Rest Json</name>
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-cdi/pom.xml
+++ b/timer-log-cdi/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log CDI</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-cdi/pom.xml
+++ b/timer-log-cdi/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log-cdi</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log CDI</name>
     <description>Camel Quarkus Example :: Timer to Log CDI</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-cdi/pom.xml
+++ b/timer-log-cdi/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log CDI</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-cdi/pom.xml
+++ b/timer-log-cdi/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log-cdi</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log CDI</name>
     <description>Camel Quarkus Example :: Timer to Log CDI</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log-kotlin</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Kotlin</name>
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <kotlin.version>1.5.21</kotlin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log-kotlin</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Kotlin</name>
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
         <kotlin.version>1.5.21</kotlin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -22,22 +22,22 @@
 
     <artifactId>camel-quarkus-examples-timer-log-main</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Main</name>
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
+        <camel-quarkus.version>2.5.0</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -22,22 +22,22 @@
 
     <artifactId>camel-quarkus-examples-timer-log-main</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Main</name>
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>2.4.0</camel-quarkus.version>
+        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->

--- a/timer-log-spring/pom.xml
+++ b/timer-log-spring/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Spring</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-spring/pom.xml
+++ b/timer-log-spring/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log-spring</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Spring</name>
     <description>Camel Quarkus Example :: Timer to Log Spring</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-spring/pom.xml
+++ b/timer-log-spring/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log-spring</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Spring</name>
     <description>Camel Quarkus Example :: Timer to Log Spring</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-spring/pom.xml
+++ b/timer-log-spring/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Spring</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-xml/pom.xml
+++ b/timer-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log XML</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-xml/pom.xml
+++ b/timer-log-xml/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log-xml</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log XML</name>
     <description>Camel Quarkus Example :: Timer to Log XML</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-xml/pom.xml
+++ b/timer-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log XML</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log-xml/pom.xml
+++ b/timer-log-xml/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log-xml</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log XML</name>
     <description>Camel Quarkus Example :: Timer to Log XML</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log</name>
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
         <quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>2.4.0</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log</name>
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <quarkus.platform.version>2.4.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.5.0.CR1</quarkus.platform.version>
         <camel-quarkus.platform.version>2.5.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.