### PR TITLE
Use https instead of http to reference xsd

### DIFF
--- a/file-split-log-xml/src/main/resources/routes/camel-routes.xml
+++ b/file-split-log-xml/src/main/resources/routes/camel-routes.xml
@@ -22,7 +22,7 @@
         xmlns="http://camel.apache.org/schema/spring"
         xsi:schemaLocation="
             http://camel.apache.org/schema/spring
-            http://camel.apache.org/schema/spring/camel-spring.xsd">
+            https://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <route id="file-xml-route">
         <from uri="file:{{camel.file.route.folder}}?noop=true&amp;delay={{camel.file.repeat.interval}}&amp;idempotent=false&amp;initialDelay=5000"/>

--- a/jdbc-datasource/src/main/resources/routes/camel-routes.xml
+++ b/jdbc-datasource/src/main/resources/routes/camel-routes.xml
@@ -22,7 +22,7 @@
         xmlns="http://camel.apache.org/schema/spring"
         xsi:schemaLocation="
             http://camel.apache.org/schema/spring
-            http://camel.apache.org/schema/spring/camel-spring.xsd">
+            https://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <route id="jdbc-datasource-route"
            autoStartup="false">

--- a/timer-log-xml/src/main/resources/routes/my-routes.xml
+++ b/timer-log-xml/src/main/resources/routes/my-routes.xml
@@ -21,7 +21,7 @@
         xmlns="http://camel.apache.org/schema/spring"
         xsi:schemaLocation="
             http://camel.apache.org/schema/spring
-            http://camel.apache.org/schema/spring/camel-spring.xsd">
+            https://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <route id="xml-route">
         <from uri="timer:from-xml?period=1000"/>


### PR DESCRIPTION
it is more secure and avoids a redirection

fixes apache/camel-quarkus#3604

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.