### PR TITLE
Re-enable KafkaIT test

### DIFF
--- a/kafka/src/main/resources/application.properties
+++ b/kafka/src/main/resources/application.properties
@@ -15,8 +15,11 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-#Kafka topic Name
+# Kafka topic Name
 kafka.topic.name=test
+
+# Kafka brokers in native test
+%prod.camel.component.kafka.brokers=${kafka.bootstrap.servers}
 
 # How often should the messages be generated and pushed to Kafka Topic
 timer.period = 10000

--- a/kafka/src/test/java/org/acme/kafka/KafkaIT.java
+++ b/kafka/src/test/java/org/acme/kafka/KafkaIT.java
@@ -17,9 +17,7 @@
 package org.acme.kafka;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import org.junit.jupiter.api.Disabled;
 
-@Disabled("https://github.com/apache/camel-quarkus/issues/3157")
 @QuarkusIntegrationTest
 public class KafkaIT extends KafkaTest {
 }


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.