### PR TITLE
Fix example for ability to use Jaeger exporter only

### DIFF
--- a/observability/README.adoc
+++ b/observability/README.adoc
@@ -63,6 +63,26 @@ You can also directly leverage MicroProfile Health APIs to create checks. Class 
 
 The tracing configuration for the application can be found within `application.properties`.
 
+Default configuration uses OTLP exporter, but it can be easily switched to Jaeger exporter with applying this change in `application.properties`:
+
+[source,shell]
+----
+- quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317
++ quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://localhost:14250
+----
+
+and this change in `pom.xml`:
+
+[source,xml]
+----
+        <dependency>
+            <groupId>io.quarkus</groupId>
+-           <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
++           <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
+        </dependency>
+----
+
+
 To view tracing events, start a tracing server. A simple way of doing this is with Docker Compose:
 
 [source,shell]

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -23,8 +23,8 @@ services:
     image: jaegertracing/all-in-one:1.33
     ports:
       - "16686:16686"
-      - "14268"
-      - "14250"
+      - "14268:14268"
+      - "14250:14250"
 
   # Collector
   otel-collector:
@@ -35,6 +35,5 @@ services:
     ports:
       - "13133:13133" # Health_check extension
       - "4317:4317"   # OTLP gRPC receiver
-      - "55680:55680" # OTLP gRPC receiver alternative port
     depends_on:
       - jaeger-all-in-one

--- a/observability/src/main/resources/application.properties
+++ b/observability/src/main/resources/application.properties
@@ -23,8 +23,10 @@ quarkus.banner.enabled = false
 # Identifier for the origin of spans created by the application
 quarkus.application.name=camel-quarkus-observability
 
-# gRPC endpoint for sending spans
+# For OTLP
 quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317
+# For Jaeger
+# quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://localhost:14250
 
 # Allow metrics to be exported as JSON. Not strictly required and is disabled by default
 quarkus.micrometer.export.json.enabled = true


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.