### PR TITLE
Disable native profile for cluster-leader-election due to apache/camel-quarkus#4095

### DIFF
--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -257,6 +257,7 @@
     </build>
 
     <profiles>
+        <!-- TODO: Enable when https://github.com/apache/camel-quarkus/issues/4095 is fixed
         <profile>
             <id>native</id>
             <activation>
@@ -289,6 +290,7 @@
                 </plugins>
             </build>
         </profile>
+        -->
         <profile>
             <id>kubernetes</id>
             <activation>


### PR DESCRIPTION
Needed until CQ `main` branch upgrades to Quarkus 2.14.x. 