### PR TITLE
Fix opentelemetry exporter

### DIFF
--- a/observability/README.adoc
+++ b/observability/README.adoc
@@ -56,26 +56,6 @@ You can also directly leverage MicroProfile Health APIs to create checks. Class 
 
 The tracing configuration for the application can be found within `application.properties`.
 
-The default configuration uses the OTLP exporter, but it can be easily switched to the Jaeger exporter by applying this change in `application.properties`:
-
-[source,shell]
-----
-- quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317
-+ quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://localhost:14250
-----
-
-and this change in `pom.xml`:
-
-[source,xml]
-----
-        <dependency>
-            <groupId>io.quarkus</groupId>
--           <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
-+           <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
-        </dependency>
-----
-
-
 To view tracing events, start a tracing server. A simple way of doing this is with Docker Compose:
 
 [source,shell]
@@ -83,7 +63,7 @@ To view tracing events, start a tracing server. A simple way of doing this is wi
 $ docker-compose up -d
 ----
 
-With the server running, browse to http://localhost:16686. Then choose 'camel-quarkus-observability' from the 'Service' drop down and click the 'Find Traces' button.
+With the server running, browse to http://localhost:16686. Then choose 'greeting-app' from the 'Service' drop down and click the 'Find Traces' button.
 
 The `platform-http` consumer route introduces a random delay to simulate latency, hence the overall time of each trace should be different. When viewing a trace, you should see
 a hierarchy of 3 spans showing the progression of the message exchange through each endpoint.

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -108,6 +108,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
 

--- a/observability/src/main/resources/application.properties
+++ b/observability/src/main/resources/application.properties
@@ -21,12 +21,10 @@
 quarkus.banner.enabled = false
 
 # Identifier for the origin of spans created by the application
-quarkus.application.name=camel-quarkus-observability
+quarkus.application.name=greeting-app
 
 # For OTLP
 quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://${TELEMETRY_COLLECTOR_COLLECTOR_SERVICE_HOST:localhost}:4317
-# For Jaeger
-# quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://${MY_JAEGER_COLLECTOR_SERVICE_HOST:localhost}:14250
 
 # Allow metrics to be exported as JSON. Not strictly required and is disabled by default
 quarkus.micrometer.export.json.enabled = true
@@ -34,9 +32,9 @@ quarkus.micrometer.export.json.enabled = true
 #
 # Camel
 #
-camel.context.name = camel-quarkus-observability
-greeting-app.service.host=${CAMEL_QUARKUS_OBSERVABILITY_SERVICE_HOST:localhost}
-greeting-app.service.port=${CAMEL_QUARKUS_OBSERVABILITY_SERVICE_PORT_HTTP:${quarkus.http.port}}
+camel.context.name = ${quarkus.application.name}
+greeting-app.service.host=${GREETING_APP_SERVICE_HOST:localhost}
+greeting-app.service.port=${GREETING_APP_SERVICE_PORT_HTTP:${quarkus.http.port}}
 %test.greeting-app.service.port=${quarkus.http.test-port}
 greeting-provider-app.service.host=localhost
 greeting-provider-app.service.port=${quarkus.http.port}


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.