### PR TITLE
Disabled native profile because of kubernetess until quarkus 2.16.0.CR1

### DIFF
--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -257,6 +257,7 @@
     </build>
 
     <profiles>
+        <!-- TODO https://github.com/apache/camel-quarkus/issues/4357
         <profile>
             <id>native</id>
             <activation>
@@ -289,6 +290,7 @@
                 </plugins>
             </build>
         </profile>
+        -->
         <profile>
             <id>kubernetes</id>
             <activation>


### PR DESCRIPTION
Disabling native compilation for the example using kubernetess.

Once quarkus is upgraded to 2.16.0.CR1, enable the profile!

More information in https://github.com/apache/camel-quarkus/issues/4357

Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.