### PR TITLE
Fix typo in jta-jpa README

### DIFF
--- a/jta-jpa/README.adoc
+++ b/jta-jpa/README.adoc
@@ -60,7 +60,7 @@ docker exec -it db-mysql mysql -uroot -proot -e \
 # Production Datasource
 %prod.quarkus.datasource.db-kind=mysql
 %prod.quarkus.datasource.username=admin
-$prod.quarkus.datasource.password=admin
+%prod.quarkus.datasource.password=admin
 %prod.quarkus.datasource.jdbc.url=mysql://localhost:3306/testdb
 %prod.quarkus.datasource.jdbc.transactions=xa
 
@@ -147,7 +147,7 @@ Stacktrace
 Test crash recovery by calling the service with "crash" content:
 [source,shell]
 ----
-curl -X POST $ADDRESS/api/message/crash
+curl -X POST $ADDRESS/api/messages/crash
 ----
 The application should be crashed, and you can not see any response.
 [source]


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.