### PR TITLE
Fix copy of eclipse-formatter-config.xml for MacOS

### DIFF
--- a/mvnw-for-each.sh
+++ b/mvnw-for-each.sh
@@ -11,7 +11,7 @@ do
     if [ -f "${pwd}/${moduleDir}/pom.xml" ]; then
         cd "${pwd}/${moduleDir}"
         ../mvnw "$@"
-        cp -t . ../eclipse-formatter-config.xml
+        cp ../eclipse-formatter-config.xml .
     fi
 done
 


### PR DESCRIPTION
There is no `-t` option on the BSD variant of `cp`.