### PR TITLE
Remove restriction for only testing projects with a native profile

### DIFF
--- a/.github/generate-test-groups.groovy
+++ b/.github/generate-test-groups.groovy
@@ -22,7 +22,7 @@ int groupId = 0
 
 // Distribute example projects across a bounded set of test groups and output as JSON
 new File(".").eachFileRecurse { file ->
-    if (file.getName() == "pom.xml" && file.text.contains("<id>native</id>")) {
+    if (file.getName() == "pom.xml") {
         if (GROUPS[groupId] == null) {
             GROUPS[groupId] = [:]
             GROUPS[groupId].name = "group-${String.format("%02d", groupId + 1)}"


### PR DESCRIPTION
Relates to https://github.com/apache/camel-quarkus-examples/pull/165#issuecomment-1761126866.