### PR TITLE
Fix quarkus.transaction-manager.object-store directory property

### DIFF
--- a/jms-jpa/src/main/resources/application.properties
+++ b/jms-jpa/src/main/resources/application.properties
@@ -37,7 +37,7 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 #%prod.quarkus.hibernate-orm.database.generation=none
 
 # Quarkus Narayana JTA
-quarkus.transaction-manager.object-store-directory=target/narayana
+quarkus.transaction-manager.object-store.directory=target/narayana
 quarkus.transaction-manager.enable-recovery=true
 
 # Camel

--- a/jta-jpa/src/main/resources/application.properties
+++ b/jta-jpa/src/main/resources/application.properties
@@ -37,7 +37,7 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 #%prod.quarkus.hibernate-orm.database.generation=none
 
 # Quarkus Narayana JTA
-quarkus.transaction-manager.object-store-directory=target/narayana
+quarkus.transaction-manager.object-store.directory=target/narayana
 quarkus.transaction-manager.enable-recovery=true
 
 # Camel


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.