### PR TITLE
Added namespaces to sample XML and fixed file reference in README

### DIFF
--- a/cxf-soap/README.adoc
+++ b/cxf-soap/README.adoc
@@ -97,7 +97,7 @@ We can also test our customer service:
 $ curl -X POST -H "Content-Type: text/xml;charset=UTF-8" -d @src/main/resources/requests/customer/getByName.xml http://localhost:8080/cxf/services/customer
 ----
 
-You can observe that we have hardcoded `test` as the name in the `SOAPBody` part in `src/main/resources/requests/customer/getByName.soap` as follows:
+You can observe that we have hardcoded `test` as the name in the `SOAPBody` part in `src/main/resources/requests/customer/getByName.xml` as follows:
 
 [source, xml]
 ----

--- a/cxf-soap/src/main/resources/requests/contact/add.xml
+++ b/cxf-soap/src/main/resources/requests/contact/add.xml
@@ -21,12 +21,12 @@
    <soapenv:Body>
       <con:addContact>
          <arg0>
-            <name>Lukas</name>
-            <address>
-               <city>New York</city>
-               <street>Sky 1234</street>
-            </address>
-            <type>PERSONAL</type>
+            <con:name>Lukas</con:name>
+            <con:address>
+               <con:city>New York</con:city>
+               <con:street>Sky 1234</con:street>
+            </con:address>
+            <con:type>PERSONAL</con:type>
          </arg0>
       </con:addContact>
    </soapenv:Body>

--- a/cxf-soap/src/main/resources/requests/customer/getByName.xml
+++ b/cxf-soap/src/main/resources/requests/customer/getByName.xml
@@ -20,7 +20,7 @@
    <soapenv:Header/>
    <soapenv:Body>
       <cus:getCustomersByName>
-         <name>Non existent</name>
+         <name>test</name>
       </cus:getCustomersByName>
    </soapenv:Body>
 </soapenv:Envelope>


### PR DESCRIPTION
Fixed an incorrect file reference in the  README.
Added namespaces to` add.xml `as this was causing errors without them.
Reset the `getByName.xml` so that the example works when following the instructions in the README.