### PR TITLE
Use Strimzi as the Kafka devservices image as it works on Power architecture

### DIFF
--- a/kafka/README.adoc
+++ b/kafka/README.adoc
@@ -14,7 +14,7 @@ The example application requires a Kafka instance.
 You do not need to provide the Kafka instance yourself
 as long as you play with the example code in dev mode (a.k.a. `mvn quarkus:dev` - read more https://quarkus.io/guides/getting-started#development-mode[here]
 or as long as you only run the supplied tests (`mvn test`).
-In those situations, Quarkus tooling starts a Redpanda image for you via https://quarkus.io/guides/kafka-dev-services[Quarkus Dev Services]
+In those situations, Quarkus tooling starts a Strimzi image for you via https://quarkus.io/guides/kafka-dev-services[Quarkus Dev Services]
 and it also configures the application so that you do not need touch anything in `application.properties`.
 
 == Start in Development mode

--- a/kafka/src/main/resources/application.properties
+++ b/kafka/src/main/resources/application.properties
@@ -15,6 +15,9 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
+# Use Strimzi as it's power architecture compatible
+quarkus.kafka.devservices.provider = strimzi
+
 # Kafka topic Name
 kafka.topic.name=test
 


### PR DESCRIPTION
Sending to `main` instead of `camel-quarkus-main` as it makes life easier for folks testing examples on Power.