### PR TITLE
Upgrade to Quarkus Platform 3.9.1

### DIFF
--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -27,13 +27,13 @@
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -29,13 +29,13 @@
     <description>Camel Quarkus Example :: Cluster leader election</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/cxf-soap/pom.xml
+++ b/cxf-soap/pom.xml
@@ -29,13 +29,13 @@
     <description>Camel Quarkus Example :: CXF SOAP</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -25,13 +25,13 @@
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>

--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -25,14 +25,14 @@
     <name>Camel Quarkus :: Examples :: JMS JPA</name>
     <description>Camel Quarkus Example :: JMS JPA</description>
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.1.4</quarkiverse-artemis.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>

--- a/jpa-idempotent-repository/pom.xml
+++ b/jpa-idempotent-repository/pom.xml
@@ -30,13 +30,13 @@
     <description>Camel Quarkus Example :: JPA Idempotent Repository</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/jta-jpa/pom.xml
+++ b/jta-jpa/pom.xml
@@ -25,13 +25,13 @@
     <name>Camel Quarkus :: Examples :: JTA JPA</name>
     <description>Camel Quarkus Example :: JTA JPA</description>
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -28,16 +28,16 @@
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
+        <camel-quarkus.version>3.9.0</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Configure XA Transactions and connection pooling</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -29,13 +29,13 @@
 
     <properties>
 
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/platform-http-security-keycloak/pom.xml
+++ b/platform-http-security-keycloak/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Platform HTTP Security Keycloak</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <kotlin.version>1.8.21</kotlin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -28,16 +28,16 @@
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
+        <camel-quarkus.version>3.9.0</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.8.1</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.9.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.9.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.