### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    target-branch: "camel-quarkus-main"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "maven"
+    target-branch: "camel-quarkus-main"
+    groups:
+      maven:
+        applies-to: version-updates
+        patterns:
+        - "*"
+    directories:
+      - "/aws-lambda"
+      - "/cluster-leader-election"
+      - "/cxf-soap"
+      - "/file-bindy-ftp"
+      - "/file-split-log-xml"
+      - "/health"
+      - "/http-log"
+      - "/jdbc-datasource"
+      - "/jms-jpa"
+      - "/jpa-idempotent-repository"
+      - "/jta-jpa"
+      - "/kafka"
+      - "/kamelet-chucknorris"
+      - "/message-bridge"
+      - "/observability"
+      - "/platform-http-security-keycloak"
+      - "/rest-json"
+      - "/timer-log-kotlin"
+      - "/timer-log-main"
+      - "/timer-log"
+      - "/vertx-websocket-chat"
+    schedule:
+      interval: "daily"
+    allow:
+      # Quarkiverse extensions
+      - dependency-name: "io.quarkiverse.*:*"
+      - dependency-name: "org.zeroturnaround:zt-exec"
+      # Test dependencies
+      - dependency-name: "org.assertj:assertj-core"
+      # Maven plugins
+      - dependency-name: "*:*-maven-plugin"
+      - dependency-name: "org.apache.maven.plugins:*"
+    ignore:
+      # Quarkus is upgraded manually
+      - dependency-name: "io.quarkus:*"
+      - dependency-name: "io.quarkus.platform:*"
+      # Camel & Camel Quarkus is upgraded manually
+      - dependency-name: "org.apache.camel:*"
+      - dependency-name: "org.apache.camel.maven:*"
+      - dependency-name: "org.apache.camel.quarkus:*"


### PR DESCRIPTION
Thought maybe it'd be best to batch and group Maven updates to avoid gazillion dependabot PRs getting opened. I think it's safe to do here given most of the updates will be for Maven plugins.

The `directories` config will hopefully be simpler in future when wildcard support is added.