### PR TITLE
Add openapi-contract-first in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,7 @@ updates:
       - "/kamelet-chucknorris"
       - "/message-bridge"
       - "/observability"
+      - "/openapi-contract-first"
       - "/platform-http-security-keycloak"
       - "/rest-json"
       - "/timer-log-kotlin"


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.