### PR TITLE
Disable cluster-leader-election native profile due to apache/camel-quarkus#6348

### DIFF
--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -262,6 +262,7 @@
     </build>
 
     <profiles>
+        <!-- TODO: https://github.com/apache/camel-quarkus/issues/6348
         <profile>
             <id>native</id>
             <activation>
@@ -294,6 +295,7 @@
                 </plugins>
             </build>
         </profile>
+        -->
         <profile>
             <id>kubernetes</id>
             <activation>


### PR DESCRIPTION
In anticipation of the CQ main branch upgrading to Quarkus 3.14.0.CR1.