### PR TITLE
Merge camel-quarkus-main branch into main (adopt Quarkus Platform 3.14.1 release)

### DIFF
--- a/artemis-elasticsearch/pom.xml
+++ b/artemis-elasticsearch/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Artemis ElasticSearch</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/artemis-elasticsearch/pom.xml
+++ b/artemis-elasticsearch/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-artemis-elasticsearch</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Artemis ElasticSearch</name>
     <description>Camel Quarkus Example :: Artemis ElasticSearch</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/artemis-elasticsearch/pom.xml
+++ b/artemis-elasticsearch/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -48,7 +48,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -21,19 +21,19 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.quarkus.examples</groupId>
     <artifactId>camel-quarkus-examples-aws-lambda</artifactId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: AWS Lambda</name>
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -27,13 +27,13 @@
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -29,13 +29,13 @@
     <description>Camel Quarkus Example :: Cluster leader election</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -262,6 +262,7 @@
     </build>
 
     <profiles>
+        <!-- TODO: https://github.com/apache/camel-quarkus/issues/6348
         <profile>
             <id>native</id>
             <activation>
@@ -294,6 +295,7 @@
                 </plugins>
             </build>
         </profile>
+        -->
         <profile>
             <id>kubernetes</id>
             <activation>

--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -23,19 +23,19 @@
 
     <artifactId>camel-quarkus-examples-cluster-leader-election</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Cluster leader election</name>
     <description>Camel Quarkus Example :: Cluster leader election</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -50,7 +50,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -108,6 +108,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/cxf-soap/pom.xml
+++ b/cxf-soap/pom.xml
@@ -29,13 +29,13 @@
     <description>Camel Quarkus Example :: CXF SOAP</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/cxf-soap/pom.xml
+++ b/cxf-soap/pom.xml
@@ -104,6 +104,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/cxf-soap/pom.xml
+++ b/cxf-soap/pom.xml
@@ -51,7 +51,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/cxf-soap/pom.xml
+++ b/cxf-soap/pom.xml
@@ -23,19 +23,19 @@
 
     <artifactId>camel-quarkus-examples-cxf-soap</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: CXF SOAP</name>
     <description>Camel Quarkus Example :: CXF SOAP</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-file-bindy-ftp</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: File Bindy FTP</name>
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -50,7 +50,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/file-bindy-ftp/src/main/kubernetes/kubernetes.yml
+++ b/file-bindy-ftp/src/main/kubernetes/kubernetes.yml
@@ -21,18 +21,18 @@ metadata:
   name: ssh-server-deployment
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-      app.kubernetes.io/version: 3.13.0
+      app.kubernetes.io/version: 3.14.0-SNAPSHOT
   template:
     metadata:
       labels:
         app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-        app.kubernetes.io/version: 3.13.0
+        app.kubernetes.io/version: 3.14.0-SNAPSHOT
     spec:
       containers:
         - name: openssh-server
@@ -57,7 +57,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   name: ftp-server
 spec:
   ports:
@@ -66,7 +66,7 @@ spec:
       targetPort: 2222
   selector:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   type: ClusterIP
 ---
 apiVersion: v1
@@ -77,7 +77,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   name: ftp-credentials
 type: Opaque
 ---

--- a/file-bindy-ftp/src/main/kubernetes/openshift.yml
+++ b/file-bindy-ftp/src/main/kubernetes/openshift.yml
@@ -21,18 +21,18 @@ metadata:
   name: ssh-server-deployment
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-      app.kubernetes.io/version: 3.13.0
+      app.kubernetes.io/version: 3.14.0-SNAPSHOT
   template:
     metadata:
       labels:
         app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-        app.kubernetes.io/version: 3.13.0
+        app.kubernetes.io/version: 3.14.0-SNAPSHOT
     spec:
       containers:
         - name: openssh-server
@@ -57,7 +57,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   name: ftp-server
 spec:
   ports:
@@ -66,7 +66,7 @@ spec:
       targetPort: 2222
   selector:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   type: ClusterIP
 ---
 apiVersion: v1
@@ -77,7 +77,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-file-bindy-ftp
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   name: ftp-credentials
 type: Opaque
 ---

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-file-log-xml</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: File To Log XML DSL</name>
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-health</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Health</name>
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -103,6 +103,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-http-log</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: HTTP Log</name>
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -21,17 +21,17 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.quarkus.examples</groupId>
     <artifactId>camel-quarkus-examples-jdbc-datasource</artifactId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.11.0</impsort-maven-plugin.version>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -39,7 +39,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -25,13 +25,13 @@
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.11.0</impsort-maven-plugin.version>

--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -40,7 +40,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>

--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
         <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
-        <quarkiverse-artemis.version>3.4.0</quarkiverse-artemis.version>
+        <quarkiverse-artemis.version>3.4.1</quarkiverse-artemis.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
         <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
-        <quarkiverse-artemis.version>3.3.0</quarkiverse-artemis.version>
+        <quarkiverse-artemis.version>3.4.0</quarkiverse-artemis.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -25,14 +25,14 @@
     <name>Camel Quarkus :: Examples :: JMS JPA</name>
     <description>Camel Quarkus Example :: JMS JPA</description>
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.4.1</quarkiverse-artemis.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.11.0</impsort-maven-plugin.version>

--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -21,18 +21,18 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.quarkus.examples</groupId>
     <artifactId>camel-quarkus-examples-jms-jpa</artifactId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
     <name>Camel Quarkus :: Examples :: JMS JPA</name>
     <description>Camel Quarkus Example :: JMS JPA</description>
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.3.0</quarkiverse-artemis.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.11.0</impsort-maven-plugin.version>

--- a/jpa-idempotent-repository/pom.xml
+++ b/jpa-idempotent-repository/pom.xml
@@ -30,13 +30,13 @@
     <description>Camel Quarkus Example :: JPA Idempotent Repository</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/jpa-idempotent-repository/pom.xml
+++ b/jpa-idempotent-repository/pom.xml
@@ -24,19 +24,19 @@
 
     <artifactId>camel-quarkus-examples-jpa-idempotent-repository</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: JPA Idempotent Repository</name>
     <description>Camel Quarkus Example :: JPA Idempotent Repository</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/jpa-idempotent-repository/pom.xml
+++ b/jpa-idempotent-repository/pom.xml
@@ -52,7 +52,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/jpa-idempotent-repository/src/main/kubernetes/kubernetes.yml
+++ b/jpa-idempotent-repository/src/main/kubernetes/kubernetes.yml
@@ -21,18 +21,18 @@ metadata:
   name: camel-quarkus-examples-mariadb-database-deployment
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-      app.kubernetes.io/version: 3.13.0
+      app.kubernetes.io/version: 3.14.0-SNAPSHOT
   template:
     metadata:
       labels:
         app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-        app.kubernetes.io/version: 3.13.0
+        app.kubernetes.io/version: 3.14.0-SNAPSHOT
     spec:
       containers:
         - name: mariadb-database
@@ -68,7 +68,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   name: mariadb-database
 spec:
   ports:
@@ -77,7 +77,7 @@ spec:
       targetPort: 3306
   selector:
     app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   type: ClusterIP
 ---
 apiVersion: v1
@@ -85,7 +85,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   name: mariadb-secret
 type: Opaque
 data:

--- a/jpa-idempotent-repository/src/main/kubernetes/openshift.yml
+++ b/jpa-idempotent-repository/src/main/kubernetes/openshift.yml
@@ -21,18 +21,18 @@ metadata:
   name: camel-quarkus-examples-mariadb-database-deployment
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-      app.kubernetes.io/version: 3.13.0
+      app.kubernetes.io/version: 3.14.0-SNAPSHOT
   template:
     metadata:
       labels:
         app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-        app.kubernetes.io/version: 3.13.0
+        app.kubernetes.io/version: 3.14.0-SNAPSHOT
     spec:
       containers:
         - name: mariadb-database
@@ -68,7 +68,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   name: mariadb-database
 spec:
   ports:
@@ -77,7 +77,7 @@ spec:
       targetPort: 3306
   selector:
     app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   type: ClusterIP
 ---
 apiVersion: v1
@@ -85,7 +85,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: camel-quarkus-examples-mariadb-database
-    app.kubernetes.io/version: 3.13.0
+    app.kubernetes.io/version: 3.14.0-SNAPSHOT
   name: mariadb-secret
 type: Opaque
 data:
@@ -104,7 +104,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: camel-quarkus-examples-jpa-idempotent-repository-flyway-init
-        app.kubernetes.io/version: 3.13.0
+        app.kubernetes.io/version: 3.14.0-SNAPSHOT
     spec:
       containers:
         - env:

--- a/jta-jpa/pom.xml
+++ b/jta-jpa/pom.xml
@@ -21,17 +21,17 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.camel.quarkus.examples</groupId>
     <artifactId>camel-quarkus-examples-jta-jpa</artifactId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
     <name>Camel Quarkus :: Examples :: JTA JPA</name>
     <description>Camel Quarkus Example :: JTA JPA</description>
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.11.0</impsort-maven-plugin.version>

--- a/jta-jpa/pom.xml
+++ b/jta-jpa/pom.xml
@@ -39,7 +39,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>

--- a/jta-jpa/pom.xml
+++ b/jta-jpa/pom.xml
@@ -25,13 +25,13 @@
     <name>Camel Quarkus :: Examples :: JTA JPA</name>
     <description>Camel Quarkus Example :: JTA JPA</description>
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.11.0</impsort-maven-plugin.version>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-kafka</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Kafka</name>
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -28,16 +28,16 @@
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
+        <camel-quarkus.version>3.14.0</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -22,22 +22,22 @@
 
     <artifactId>camel-quarkus-examples-kamelet-chucknorris</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Kamelet Chuck Norris</name>
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>3.13.0</camel-quarkus.version>
+        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -52,7 +52,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
 
         <quarkus.runner>${project.build.directory}/quarkus-app/quarkus-run.jar</quarkus.runner>
     </properties>

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-message-bridge</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Message Bridge</name>
     <description>Camel Quarkus Example :: Configure XA Transactions and connection pooling</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
 
         <quarkus-artemis-jms.version>3.4.1</quarkus-artemis-jms.version>
         <assertj.version>3.26.3</assertj.version>

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -51,7 +51,7 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
 
-        <quarkus-artemis-jms.version>3.3.0</quarkus-artemis-jms.version>
+        <quarkus-artemis-jms.version>3.4.0</quarkus-artemis-jms.version>
         <assertj.version>3.26.3</assertj.version>
     </properties>
 

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Configure XA Transactions and connection pooling</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -51,7 +51,7 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
 
-        <quarkus-artemis-jms.version>3.4.0</quarkus-artemis-jms.version>
+        <quarkus-artemis-jms.version>3.4.1</quarkus-artemis-jms.version>
         <assertj.version>3.26.3</assertj.version>
     </properties>
 

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -29,13 +29,13 @@
 
     <properties>
 
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -50,7 +50,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -22,7 +22,7 @@
 
     <artifactId>camel-quarkus-examples-observability</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Observability</name>
     <description>Camel Quarkus Example :: Observability</description>
@@ -30,12 +30,12 @@
     <properties>
 
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-examples-openapi-contract-first</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: openapi-contract-first</name>
     <description>Camel Quarkus Example :: openapi-contract-first</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: openapi-contract-first</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/platform-http-security-keycloak/pom.xml
+++ b/platform-http-security-keycloak/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-platform-http-security-keycloak</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Platform HTTP Security Keycloak</name>
     <description>Camel Quarkus Example :: Platform HTTP Security Keycloak</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/platform-http-security-keycloak/pom.xml
+++ b/platform-http-security-keycloak/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/platform-http-security-keycloak/pom.xml
+++ b/platform-http-security-keycloak/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Platform HTTP Security Keycloak</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-rest-json</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Rest Json</name>
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
         <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
-        <quarkiverse-artemis.version>3.4.0</quarkiverse-artemis.version>
+        <quarkiverse-artemis.version>3.4.1</quarkiverse-artemis.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -22,7 +22,7 @@
 
     <artifactId>camel-quarkus-examples-saga</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Saga</name>
     <description>Camel Quarkus Example :: Saga</description>
@@ -30,13 +30,13 @@
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.3.0</quarkiverse-artemis.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -29,14 +29,14 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.4.1</quarkiverse-artemis.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
         <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
-        <quarkiverse-artemis.version>3.3.0</quarkiverse-artemis.version>
+        <quarkiverse-artemis.version>3.4.0</quarkiverse-artemis.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -51,7 +51,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <modules>

--- a/saga/saga-app/pom.xml
+++ b/saga/saga-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-        <version>3.13.0</version>
+        <version>3.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-app</artifactId>

--- a/saga/saga-flight-service/pom.xml
+++ b/saga/saga-flight-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-        <version>3.13.0</version>
+        <version>3.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-flight</artifactId>

--- a/saga/saga-payment-service/pom.xml
+++ b/saga/saga-payment-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-	<version>3.13.0</version>
+	<version>3.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-payment</artifactId>

--- a/saga/saga-train-service/pom.xml
+++ b/saga/saga-train-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-        <version>3.13.0</version>
+        <version>3.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-train</artifactId>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -35,7 +35,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
         <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
-        <kotlin.version>2.0.0</kotlin.version>
+        <kotlin.version>2.0.10</kotlin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <kotlin.version>2.0.10</kotlin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -50,7 +50,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/timer-log-kotlin/pom.xml
+++ b/timer-log-kotlin/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log-kotlin</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Kotlin</name>
     <description>Camel Quarkus Example :: Timer to Log Kotlin</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
         <kotlin.version>2.0.0</kotlin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -22,22 +22,22 @@
 
     <artifactId>camel-quarkus-examples-timer-log-main</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log Main</name>
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>3.13.0</camel-quarkus.version>
+        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -28,16 +28,16 @@
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <!-- TODO: https://github.com/apache/camel-quarkus/issues/3156 -->
-        <camel-quarkus.version>${camel-quarkus.platform.version}</camel-quarkus.version>
+        <camel-quarkus.version>3.14.0</camel-quarkus.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -52,7 +52,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
 
         <quarkus.runner>${project.build.directory}/quarkus-app/quarkus-run.jar</quarkus.runner>
     </properties>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-timer-log</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Timer Log</name>
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/vertx-websocket-chat/pom.xml
+++ b/vertx-websocket-chat/pom.xml
@@ -22,19 +22,19 @@
 
     <artifactId>camel-quarkus-examples-vertx-websocket-chat</artifactId>
     <groupId>org.apache.camel.quarkus.examples</groupId>
-    <version>3.13.0</version>
+    <version>3.14.0-SNAPSHOT</version>
 
     <name>Camel Quarkus :: Examples :: Vertx-Websocket chat</name>
     <description>Camel Quarkus Example :: Implementing Websocket</description>
 
     <properties>
         <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/vertx-websocket-chat/pom.xml
+++ b/vertx-websocket-chat/pom.xml
@@ -28,13 +28,13 @@
     <description>Camel Quarkus Example :: Implementing Websocket</description>
 
     <properties>
-        <quarkus.platform.version>3.13.0</quarkus.platform.version>
-        <camel-quarkus.platform.version>3.14.0-SNAPSHOT</camel-quarkus.platform.version>
+        <quarkus.platform.version>3.14.1</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/vertx-websocket-chat/pom.xml
+++ b/vertx-websocket-chat/pom.xml
@@ -49,7 +49,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.