### PR TITLE
Data Extract: fix the file loading commands

### DIFF
--- a/data-extract-langchain4j/README.adoc
+++ b/data-extract-langchain4j/README.adoc
@@ -59,8 +59,7 @@ Let's atomically copy/move the transcript files to the input folder named `targe
 
 [source,shell]
 ----
-cp -rf src/test/resources/transcripts/ target/transcripts-tmp
-mv target/transcripts-tmp/*.json target/transcripts/
+./send-conversations-to-camel-route.sh
 ----
 
 The Camel route should output a log as below:

--- a/data-extract-langchain4j/send-conversations-to-camel-route.sh
+++ b/data-extract-langchain4j/send-conversations-to-camel-route.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mkdir -p target/transcripts-tmp
+mkdir -p target/transcripts
+cp -rf src/test/resources/transcripts/* target/transcripts-tmp
+mv target/transcripts-tmp/*.json target/transcripts/


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.