### PR TITLE
data-extract: Fix possible test flakiness

### DIFF
--- a/data-extract-langchain4j/src/main/java/org/acme/extraction/Routes.java
+++ b/data-extract-langchain4j/src/main/java/org/acme/extraction/Routes.java
@@ -33,7 +33,7 @@ public class Routes extends RouteBuilder {
     public void configure() {
 
         // Consumes file documents that contain conversation transcripts (JSON format)
-        from("file:target/transcripts")
+        from("file:target/transcripts?sortBy=file:name")
                 .log("A document has been received by the camel-quarkus-file extension: ${body}")
                 .setHeader("expectedDateFormat", constant("YYYY-MM-DD"))
                 // The CustomPojoExtractionService transforms the conversation transcript into a CustomPojoExtractionService.CustomPojo


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.