### PR TITLE
Message-brodge: removed restriction to have at least 10% free disk space

### DIFF
--- a/message-bridge/src/main/resources/application.properties
+++ b/message-bridge/src/main/resources/application.properties
@@ -45,3 +45,6 @@ dummy.resource.directory=target/DummyXAResource
 %openshift.dummy.resource.directory=/storage/DummyXAResource
 %kubernetes.dummy.resource.directory=/storage/DummyXAResource
 quarkus.transaction-manager.enable-recovery=true
+
+# do not block artemis if there is less than 10% of free disk space
+quarkus.artemis.devservices.extra-args=--no-autotune --mapped --no-fsync --java-options=-Dbrokerconfig.maxDiskUsage=-1


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/6821

Restriction for the free space is remved.

Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.