### PR TITLE
data-extract-langchain4j: use the ai service resolution by interface

### DIFF
--- a/artemis-elasticsearch/pom.xml
+++ b/artemis-elasticsearch/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Artemis ElasticSearch</description>
 
     <properties>
-          <quarkus.platform.version>3.17.3</quarkus.platform.version>
+          <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -27,7 +27,7 @@
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -29,7 +29,7 @@
     <description>Camel Quarkus Example :: Cluster leader election</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/cxf-soap/pom.xml
+++ b/cxf-soap/pom.xml
@@ -29,7 +29,7 @@
     <description>Camel Quarkus Example :: CXF SOAP</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/data-extract-langchain4j/pom.xml
+++ b/data-extract-langchain4j/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
 
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/data-extract-langchain4j/src/main/java/org/acme/extraction/Routes.java
+++ b/data-extract-langchain4j/src/main/java/org/acme/extraction/Routes.java
@@ -24,9 +24,6 @@ import org.apache.camel.builder.RouteBuilder;
 public class Routes extends RouteBuilder {
 
     @Inject
-    CustomPojoExtractionService customPojoExtractionService;
-
-    @Inject
     CustomPojoStore customPojoStore;
 
     @Override
@@ -37,7 +34,7 @@ public class Routes extends RouteBuilder {
                 .log("A document has been received by the camel-quarkus-file extension: ${body}")
                 .setHeader("expectedDateFormat", constant("YYYY-MM-DD"))
                 // The CustomPojoExtractionService transforms the conversation transcript into a CustomPojoExtractionService.CustomPojo
-                .bean(customPojoExtractionService)
+                .bean(CustomPojoExtractionService.class)
                 // Store extracted CustomPojoExtractionService.CustomPojos objects into the CustomPojoStore for later inspection
                 .bean(customPojoStore);
 

--- a/fhir/pom.xml
+++ b/fhir/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: FHIR</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: JMS JPA</name>
     <description>Camel Quarkus Example :: JMS JPA</description>
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.6.0</quarkiverse-artemis.version>
 

--- a/jpa-idempotent-repository/pom.xml
+++ b/jpa-idempotent-repository/pom.xml
@@ -30,7 +30,7 @@
     <description>Camel Quarkus Example :: JPA Idempotent Repository</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/jta-jpa/pom.xml
+++ b/jta-jpa/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: JTA JPA</name>
     <description>Camel Quarkus Example :: JTA JPA</description>
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Configure XA Transactions and connection pooling</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
 
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: openapi-contract-first</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/platform-http-security-keycloak/pom.xml
+++ b/platform-http-security-keycloak/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Platform HTTP Security Keycloak</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -29,7 +29,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.6.0</quarkiverse-artemis.version>
 

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/vertx-websocket-chat/pom.xml
+++ b/vertx-websocket-chat/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Implementing Websocket</description>
 
     <properties>
-        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+        <quarkus.platform.version>3.17.4</quarkus.platform.version>
         <camel-quarkus.platform.version>3.18.0-SNAPSHOT</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.