### PR TITLE
[3.15.x] Upgrade quarkus-artemis to 3.5.1

### DIFF
--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <quarkus.platform.version>3.15.2</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
-        <quarkiverse-artemis.version>3.4.2</quarkiverse-artemis.version>
+        <quarkiverse-artemis.version>3.5.1</quarkiverse-artemis.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -51,7 +51,7 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
 
-        <quarkiverse-artemis.version>3.4.2</quarkiverse-artemis.version>
+        <quarkiverse-artemis.version>3.5.1</quarkiverse-artemis.version>
         <assertj.version>3.26.3</assertj.version>
     </properties>
 

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <quarkus.platform.version>3.15.2</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
-        <quarkiverse-artemis.version>3.4.2</quarkiverse-artemis.version>
+        <quarkiverse-artemis.version>3.5.1</quarkiverse-artemis.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.