### PR TITLE
Fix observability example for Kubernetes env

### DIFF
--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -114,6 +114,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/observability/src/main/java/org/acme/observability/TimerRoute.java
+++ b/observability/src/main/java/org/acme/observability/TimerRoute.java
@@ -22,7 +22,7 @@ public class TimerRoute extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("timer:greeting?period=10000")
+        from("timer:greeting?delay=10000&period=10000")
                 .bean("timerCounter", "count")
                 .to("http://{{greeting-app.service.host}}:{{greeting-app.service.port}}/greeting");
     }

--- a/observability/src/main/java/org/acme/observability/health/camel/CustomLivenessCheck.java
+++ b/observability/src/main/java/org/acme/observability/health/camel/CustomLivenessCheck.java
@@ -40,7 +40,7 @@ public class CustomLivenessCheck extends AbstractHealthCheck {
         int hits = hitCount.incrementAndGet();
 
         // Flag the check as DOWN on every 5th invocation (but not on Kubernetes), else it is UP
-        if (hits % 5 == 0 && System.getenv("KUBERNETES_NAMESPACE") == null) {
+        if (hits % 5 == 0 && System.getenv("KUBERNETES_PORT") == null) {
             builder.down();
         } else {
             builder.up();

--- a/observability/src/test/java/org/acme/observability/ObservabilityTest.java
+++ b/observability/src/test/java/org/acme/observability/ObservabilityTest.java
@@ -16,10 +16,12 @@
  */
 package org.acme.observability;
 
+import java.time.Duration;
 import java.util.Arrays;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -47,15 +49,16 @@ public class ObservabilityTest {
     @Test
     public void metrics() {
         // Verify Camel metrics are available
-        String prometheusMetrics = RestAssured
-                .get(getManagementPrefix() + "/observe/metrics")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body().asString();
-
-        assertEquals(3,
-                Arrays.stream(prometheusMetrics.split("\n")).filter(line -> line.contains("purpose=\"example\"")).count());
+        Awaitility.await().pollInterval(Duration.ofSeconds(5)).atMost(Duration.ofMinutes(1)).untilAsserted(() -> {
+            String prometheusMetrics = RestAssured
+                    .get(getManagementPrefix() + "/observe/metrics")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .body().asString();
+            assertEquals(3,
+                    Arrays.stream(prometheusMetrics.split("\n")).filter(line -> line.contains("purpose=\"example\"")).count());
+        });
     }
 
     @Test


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.