### PR TITLE
Enable tracing by default

### DIFF
--- a/observability/README.adoc
+++ b/observability/README.adoc
@@ -152,6 +152,8 @@ Configure the OpenTelemetry exporter in `application.properties`:
 ----
 # We are using a property placeholder to be able to test this example in convenient way in a cloud environment
 quarkus.otel.exporter.otlp.traces.endpoint = http://${TELEMETRY_COLLECTOR_COLLECTOR_SERVICE_HOST:localhost}:4317
+# To enable tracing (it is disabled by default via camel-quarkus-observability-services)
+quarkus.otel.sdk.disabled=false
 ----
 
 NOTE: For information about other OpenTelemetry exporters, refer to the Camel Quarkus OpenTelemetry https://camel.apache.org/camel-quarkus/next/reference/extensions/opentelemetry.html#extensions-opentelemetry-usage-exporters[extension documentation].

--- a/observability/src/main/java/org/acme/observability/Routes.java
+++ b/observability/src/main/java/org/acme/observability/Routes.java
@@ -36,11 +36,13 @@ public class Routes extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         from("platform-http:/greeting")
+                .log("Received at greeting: ${body}")
                 .removeHeaders("*")
                 .process(this::countGreeting)
                 .to("http://localhost:{{greeting-provider-app.service.port}}/greeting-provider");
 
         from("platform-http:/greeting-provider")
+                .log("Received at greeting-provider: ${body}")
                 // Random delay to simulate latency
                 .to("micrometer:counter:org.acme.observability.greeting-provider?tags=type=events,purpose=example")
                 .delay(simple("${random(1000, 5000)}"))

--- a/observability/src/main/java/org/acme/observability/TimerRoute.java
+++ b/observability/src/main/java/org/acme/observability/TimerRoute.java
@@ -16,13 +16,19 @@
  */
 package org.acme.observability;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.camel.builder.RouteBuilder;
 
 public class TimerRoute extends RouteBuilder {
 
+    AtomicInteger counter = new AtomicInteger();
+
     @Override
     public void configure() throws Exception {
         from("timer:greeting?delay=10000&period=10000")
+                .setBody(exchange -> "Custom body #" + counter.incrementAndGet())
+                .log("Generated from timer: ${body}")
                 .bean("timerCounter", "count")
                 .to("http://{{greeting-app.service.host}}:{{greeting-app.service.port}}/greeting");
     }

--- a/observability/src/main/resources/application.properties
+++ b/observability/src/main/resources/application.properties
@@ -30,6 +30,8 @@ quarkus.application.name = camel-quarkus-observability
 # For OTLP
 quarkus.otel.exporter.otlp.traces.endpoint = http://${TELEMETRY_COLLECTOR_COLLECTOR_SERVICE_HOST:localhost}:4317
 quarkus.otel.exporter.otlp.traces.timeout = 30s
+# To enable tracing (it is disabled by default via camel-quarkus-observability-services)
+quarkus.otel.sdk.disabled=false
 
 #
 # Camel


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.