### PR TITLE
Propagate Kafka broker URL property in test and prod modes

### DIFF
--- a/cluster-leader-election/src/main/resources/application.properties
+++ b/cluster-leader-election/src/main/resources/application.properties
@@ -20,6 +20,9 @@
 quarkus.banner.enabled = false
 quarkus.log.file.enable = true
 
+# No need for k8s dev services in this project
+quarkus.kubernetes-client.devservices.enabled = false
+
 #
 # Quarkus - Camel
 #

--- a/fhir/src/main/resources/application.properties
+++ b/fhir/src/main/resources/application.properties
@@ -17,6 +17,9 @@
 
 quarkus.banner.enabled = false
 
+# No need for k8s dev services in this project
+quarkus.kubernetes-client.devservices.enabled = false
+
 # Camel FHIR configuration
 fhir.http.server.host = ${FHIR_SERVER_SERVICE_HOST:localhost}
 fhir.http.server.port = ${FHIR_SERVER_SERVICE_PORT:8080}

--- a/file-bindy-ftp/src/main/resources/application.properties
+++ b/file-bindy-ftp/src/main/resources/application.properties
@@ -17,6 +17,9 @@
 
 quarkus.banner.enabled = false
 
+# No need for k8s dev services in this project
+quarkus.kubernetes-client.devservices.enabled = false
+
 # Uncomment if your application image is to be pushed to an external registry
 #quarkus.container-image.registry=my.docker-registry.net
 

--- a/kafka/src/main/resources/application.properties
+++ b/kafka/src/main/resources/application.properties
@@ -22,7 +22,7 @@ quarkus.kafka.devservices.provider = strimzi
 kafka.topic.name=test
 
 # Kafka brokers in native test
-%prod.camel.component.kafka.brokers=${kafka.bootstrap.servers}
+%test,prod.camel.component.kafka.brokers=${kafka.bootstrap.servers}
 
 # How often should the messages be generated and pushed to Kafka Topic
 timer.period = 10000

--- a/kafka/src/main/resources/application.properties
+++ b/kafka/src/main/resources/application.properties
@@ -15,6 +15,9 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
+# No need for k8s dev services in this project
+quarkus.kubernetes-client.devservices.enabled = false
+
 # Use Strimzi as it's power architecture compatible
 quarkus.kafka.devservices.provider = strimzi
 


### PR DESCRIPTION
Handles a change coming in Quarkus 3.23.x.