### PR TITLE
Avoid using reserved word ApiResponse in OpenAPI contract first spec

### DIFF
--- a/openapi-contract-first/src/main/openapi/petstore.json
+++ b/openapi-contract-first/src/main/openapi/petstore.json
@@ -495,7 +495,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/ApiResponse"
+									"$ref": "#/components/schemas/ModelApiResponse"
 								}
 							}
 						}
@@ -1168,7 +1168,7 @@
 					"name": "pet"
 				}
 			},
-			"ApiResponse": {
+			"ModelApiResponse": {
 				"type": "object",
 				"properties": {
 					"code": {


### PR DESCRIPTION
Otherwise you get a lot of ugly warnings from the Swagger internals.