### PR TITLE
Move Kafka example k8s devservice disablement config to Maven properties

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -329,6 +329,9 @@
                     <name>kubernetes</name>
                 </property>
             </activation>
+            <properties>
+                <quarkus.kubernetes-client.devservices.enabled>false</quarkus.kubernetes-client.devservices.enabled>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>
@@ -347,6 +350,9 @@
                     <name>openshift</name>
                 </property>
             </activation>
+            <properties>
+                <quarkus.kubernetes-client.devservices.enabled>false</quarkus.kubernetes-client.devservices.enabled>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/kafka/src/main/resources/application.properties
+++ b/kafka/src/main/resources/application.properties
@@ -15,9 +15,6 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-# No need for k8s dev services in this project
-quarkus.kubernetes-client.devservices.enabled = false
-
 # Use Strimzi as it's power architecture compatible
 quarkus.kafka.devservices.provider = strimzi
 quarkus.kafka.devservices.image-name = quay.io/strimzi-test-container/test-container:0.114.0-kafka-4.1.0


### PR DESCRIPTION
Required for Quarkus 3.35 due to some changes in the k8s extension config.