### PR TITLE
[camel-4.21] Fix #8691 CXF SOAP example for CAMEL-23526 header name changes

### DIFF
--- a/cxf-soap/src/main/java/org/acme/cxf/soap/pojo/PojoCxfConsumerRouteBuilder.java
+++ b/cxf-soap/src/main/java/org/acme/cxf/soap/pojo/PojoCxfConsumerRouteBuilder.java
@@ -43,6 +43,6 @@ public class PojoCxfConsumerRouteBuilder extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         from("cxf:bean:contact")
-                .recipientList(simple("bean:inMemoryContactService?method=${header.operationName}"));
+                .recipientList(simple("bean:inMemoryContactService?method=${header.CamelCxfOperationName}"));
     }
 }

--- a/cxf-soap/src/main/java/org/acme/cxf/soap/pojo/PojoCxfConsumerRouteBuilder.java
+++ b/cxf-soap/src/main/java/org/acme/cxf/soap/pojo/PojoCxfConsumerRouteBuilder.java
@@ -23,6 +23,8 @@ import org.acme.cxf.soap.pojo.service.ContactService;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.cxf.jaxws.CxfEndpoint;
 
+import static org.acme.cxf.soap.utils.CxfServerUtils.OPERATION_NAME_HEADER;
+
 /**
  * This class demonstrate how to expose a SOAP endpoint starting from java classes
  */
@@ -43,6 +45,6 @@ public class PojoCxfConsumerRouteBuilder extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         from("cxf:bean:contact")
-                .recipientList(simple("bean:inMemoryContactService?method=${header.CamelCxfOperationName}"));
+                .recipientList(simple("bean:inMemoryContactService?method=" + OPERATION_NAME_HEADER));
     }
 }

--- a/cxf-soap/src/main/java/org/acme/cxf/soap/pojo/PojoCxfProducerRouteBuilder.java
+++ b/cxf-soap/src/main/java/org/acme/cxf/soap/pojo/PojoCxfProducerRouteBuilder.java
@@ -25,6 +25,7 @@ import org.acme.cxf.soap.pojo.service.Contacts;
 import org.acme.cxf.soap.utils.CxfServerUtils;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.cxf.common.DataFormat;
+import org.apache.camel.component.cxf.common.message.CxfConstants;
 import org.apache.camel.component.cxf.jaxws.CxfEndpoint;
 import org.apache.camel.model.dataformat.JsonLibrary;
 import org.apache.camel.model.rest.RestBindingMode;
@@ -60,9 +61,11 @@ public class PojoCxfProducerRouteBuilder extends RouteBuilder {
                 .to("direct:contacts");
 
         from("direct:contact")
+                .setHeader(CxfConstants.OPERATION_NAME, constant("addContact"))
                 .to("cxf:bean:soapClientEndpointPojo");
 
         from("direct:contacts")
+                .setHeader(CxfConstants.OPERATION_NAME, constant("getContacts"))
                 .to("cxf:bean:soapClientEndpointPojo")
                 .convertBodyTo(Contacts.class)
                 .marshal().json(JsonLibrary.Jackson);

--- a/cxf-soap/src/main/java/org/acme/cxf/soap/utils/CxfServerUtils.java
+++ b/cxf-soap/src/main/java/org/acme/cxf/soap/utils/CxfServerUtils.java
@@ -17,10 +17,13 @@
 package org.acme.cxf.soap.utils;
 
 import io.quarkus.runtime.LaunchMode;
+import org.apache.camel.component.cxf.common.message.CxfConstants;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 public final class CxfServerUtils {
+    public static final String OPERATION_NAME_HEADER = "${header.%s}".formatted(CxfConstants.OPERATION_NAME);
+
     private CxfServerUtils() {
     }
 

--- a/cxf-soap/src/main/java/org/acme/cxf/soap/wsdl/MyWsdlRouteBuilder.java
+++ b/cxf-soap/src/main/java/org/acme/cxf/soap/wsdl/MyWsdlRouteBuilder.java
@@ -63,7 +63,7 @@ public class MyWsdlRouteBuilder extends RouteBuilder {
     public void configure() throws Exception {
         // CustomerService is generated with quarkus-maven-plugin:generate-code during the build
         from("cxf:bean:customer")
-                .recipientList(simple("direct:${header.operationName}"));
+                .recipientList(simple("direct:${header.CamelCxfOperationName}"));
 
         from("direct:getCustomersByName").process(exchange -> {
             String name = exchange.getIn().getBody(String.class);

--- a/cxf-soap/src/main/java/org/acme/cxf/soap/wsdl/MyWsdlRouteBuilder.java
+++ b/cxf-soap/src/main/java/org/acme/cxf/soap/wsdl/MyWsdlRouteBuilder.java
@@ -31,6 +31,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.cxf.jaxws.CxfEndpoint;
 import org.apache.cxf.message.MessageContentsList;
 
+import static org.acme.cxf.soap.utils.CxfServerUtils.OPERATION_NAME_HEADER;
+
 /**
  * This class demonstrate how to expose a SOAP endpoint starting from a wsdl, using the
  * quarkus-maven-plugin:generate-code
@@ -63,7 +65,7 @@ public class MyWsdlRouteBuilder extends RouteBuilder {
     public void configure() throws Exception {
         // CustomerService is generated with quarkus-maven-plugin:generate-code during the build
         from("cxf:bean:customer")
-                .recipientList(simple("direct:${header.CamelCxfOperationName}"));
+                .recipientList(simple("direct:" + OPERATION_NAME_HEADER));
 
         from("direct:getCustomersByName").process(exchange -> {
             String name = exchange.getIn().getBody(String.class);


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/8691

CAMEL-23526 renamed CXF header constants to follow Camel naming conventions:
- operationName → CamelCxfOperationName
- operationNamespace → CamelCxfOperationNamespace

