### PR TITLE
CAMEL-23655: Update GitHub topics for better discoverability

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,9 +20,20 @@ github:
   homepage: https://camel.apache.org
   labels:
     - camel
-    - integration
-    - java
+    - examples
     - quarkus
+    - integration
+    - integration-framework
+    - enterprise-integration-patterns
+    - java
+    - cloud-native
+    - kubernetes
+    - kafka
+    - rest-api
+    - yaml
+    - data-transformation
+    - microservices
+    - mcp
   enabled_merge_buttons:
     merge: false
     rebase: true


### PR DESCRIPTION
## Summary

- Expand GitHub topics from 4 to 15 (out of 20 max) to improve discoverability
- Add `examples` to identify this as a samples/examples repository
- Add `integration-framework`, `enterprise-integration-patterns`
- Add deployment/ecosystem: `cloud-native`, `kubernetes`, `kafka`
- Add capabilities: `rest-api`, `yaml`, `data-transformation`
- Add `microservices`, `mcp`

Follows the same topic expansion done in apache/camel#23673.

## Test plan

- [ ] After merge, verify topics appear on https://github.com/apache/camel-quarkus-examples

_Claude Code on behalf of Claus Ibsen_