### PR TITLE
Fix maven-resources-plugin version warning

### DIFF
--- a/http-pqc-j21/pom.xml
+++ b/http-pqc-j21/pom.xml
@@ -45,7 +45,7 @@
         <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
-        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     </properties>
 
@@ -230,6 +230,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-certificates-to-classes</id>


### PR DESCRIPTION
## Summary
- Add missing version reference to maven-resources-plugin declaration
- Update maven-resources-plugin from 3.3.1 to 3.5.0 (latest version)

Fixes the Maven warning:
```
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-resources-plugin is missing. @ line 230, column 21
```

## Test plan
- [x] Run `mvn validate` to verify the warning is resolved
- [x] Version follows the project's naming convention (`${maven-resources-plugin.version}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)