### PR TITLE
Align AI assistants related exclusions to Camel Quarkus .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,8 @@ flight.*
 train.*
 app.*
 
-# AI assistants
+# Claude
+.claude
+
+# Bob
 .bob


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.