### PR TITLE
[3.33.x] Fix CXF SOAP routes for Camel 4.18.3 header change (CAMEL-23379)

### DIFF
--- a/cxf-soap/src/main/java/org/acme/cxf/soap/pojo/PojoCxfConsumerRouteBuilder.java
+++ b/cxf-soap/src/main/java/org/acme/cxf/soap/pojo/PojoCxfConsumerRouteBuilder.java
@@ -43,6 +43,6 @@ public class PojoCxfConsumerRouteBuilder extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         from("cxf:bean:contact")
-                .recipientList(simple("bean:inMemoryContactService?method=${header.operationName}"));
+                .recipientList(simple("bean:inMemoryContactService?method=${header.CamelCxfOperationName}"));
     }
 }

--- a/cxf-soap/src/main/java/org/acme/cxf/soap/wsdl/MyWsdlRouteBuilder.java
+++ b/cxf-soap/src/main/java/org/acme/cxf/soap/wsdl/MyWsdlRouteBuilder.java
@@ -63,7 +63,7 @@ public class MyWsdlRouteBuilder extends RouteBuilder {
     public void configure() throws Exception {
         // CustomerService is generated with quarkus-maven-plugin:generate-code during the build
         from("cxf:bean:customer")
-                .recipientList(simple("direct:${header.operationName}"));
+                .recipientList(simple("direct:${header.CamelCxfOperationName}"));
 
         from("direct:getCustomersByName").process(exchange -> {
             String name = exchange.getIn().getBody(String.class);


### PR DESCRIPTION
Required for https://github.com/apache/camel-quarkus/pull/8809

Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.