### PR TITLE
Fixes #8897: Add CyberArk Vault example

### DIFF
--- a/cyberark-vault/README.adoc
+++ b/cyberark-vault/README.adoc
@@ -1,0 +1,118 @@
+= CyberArk Vault: A Camel Quarkus example
+:cq-example-description: An example that shows how to retrieve secrets from CyberArk Vault via property placeholders with a local Conjur container
+
+{cq-description}
+
+TIP: Check the https://camel.apache.org/camel-quarkus/latest/first-steps.html[Camel Quarkus User guide] for prerequisites
+and other general information.
+
+== Prerequisites
+
+* Docker (for running the Conjur containers)
+
+== Starting Conjur
+
+The example requires a running Conjur instance. A helper script is provided to start a local Conjur
+environment via Docker Compose:
+
+[source,shell]
+----
+$ ./start-conjur.sh
+----
+
+The script starts the containers, initializes the account, loads the security policy and prints the
+`export` commands you need to run. Copy and execute them in your shell.
+
+Alternatively, to use an existing Conjur instance, set the following environment variables manually:
+
+[source,shell]
+----
+export CQ_CONJUR_URL=http://localhost:9080
+export CQ_CONJUR_ACCOUNT=myConjurAccount
+export CQ_CONJUR_READ_USER=host/BotApp/myDemoApp
+export CQ_CONJUR_READ_USER_API_KEY=...
+export CQ_CONJUR_READ_WRITE_USER=user/Dave@BotApp
+export CQ_CONJUR_READ_WRITE_USER_API_KEY=...
+----
+
+To stop the Docker-based Conjur environment:
+
+[source,shell]
+----
+$ ./start-conjur.sh stop
+----
+
+== Start in the Development mode
+
+With the environment variables set, start the example in dev mode:
+
+[source,shell]
+----
+$ mvn clean compile quarkus:dev
+----
+
+Then look at the log output in the console. There is a timer route that periodically resolves the secret
+via the CyberArk property placeholder. The first several messages will show that no secret is stored yet.
+To store a secret, open a new terminal and run:
+
+[source,shell]
+----
+$ curl -X POST http://localhost:8080/cyberark-vault/createSecret -d 'my-secret-value'
+----
+
+Following messages will show the resolved secret value. As we run the example in Quarkus Dev Mode, you can
+edit the source code and have live updates.
+
+TIP: Please refer to the Development mode section of
+https://camel.apache.org/camel-quarkus/latest/first-steps.html#_development_mode[Camel Quarkus User guide] for more details.
+
+== Package and run the application
+
+Once you are done with developing you may want to package and run the application.
+Make sure the Conjur environment variables are set (see <<Starting Conjur>>).
+
+TIP: Find more details about the JVM mode and Native mode in the Package and run section of
+https://camel.apache.org/camel-quarkus/latest/first-steps.html#_package_and_run_the_application[Camel Quarkus User guide]
+
+=== JVM mode
+
+[source,shell]
+----
+$ mvn clean package
+$ java -jar target/quarkus-app/quarkus-run.jar
+...
+[io.quarkus] (main) camel-quarkus-examples-... started in 1.163s.
+----
+
+=== Native mode
+
+IMPORTANT: Native mode requires having GraalVM and other tools installed. Please check the Prerequisites section
+of https://camel.apache.org/camel-quarkus/latest/first-steps.html#_prerequisites[Camel Quarkus User guide].
+
+To prepare a native executable using GraalVM, run the following command:
+
+[source,shell]
+----
+$ mvn clean package -Dnative
+$ ./target/*-runner
+...
+[io.quarkus] (main) camel-quarkus-examples-... started in 0.013s.
+...
+----
+
+== Running the tests
+
+By default, the tests use testcontainers to start a local Conjur environment automatically:
+
+[source,shell]
+----
+$ mvn clean verify
+----
+
+To run the tests against an external Conjur instance instead, set the environment variables described
+in <<Starting Conjur>> before running the command. When all `CQ_CONJUR_*` variables are present,
+testcontainers are skipped and the tests run against the external instance.
+
+== Feedback
+
+Please report bugs and propose improvements via https://github.com/apache/camel-quarkus/issues[GitHub issues of Camel Quarkus] project.

--- a/cyberark-vault/docker-compose.yml
+++ b/cyberark-vault/docker-compose.yml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+services:
+  database:
+    image: mirror.gcr.io/postgres:17.5
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: SuperSecretPg
+      POSTGRES_DB: postgres
+
+  conjur:
+    image: mirror.gcr.io/cyberark/conjur:1.24.0
+    command: server
+    depends_on:
+      - database
+    ports:
+      - "${CONJUR_PORT:-9080}:80"
+    environment:
+      DATABASE_URL: postgres://postgres:SuperSecretPg@database/postgres
+      CONJUR_DATA_KEY: changeitchangeitchangeitchangeitchangeitIhc=
+      CONJUR_AUTHENTICATORS: ""
+      CONJUR_TELEMETRY_ENABLED: "false"
+      CONJUR_API_RESOURCE_LIST_LIMIT_MAX: "5000"

--- a/cyberark-vault/eclipse-formatter-config.xml
+++ b/cyberark-vault/eclipse-formatter-config.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<profiles version="8">
+    <profile name="Camel Java Conventions" version="8" kind="CodeFormatterProfile">
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_return_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="8"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="128"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="CHECKSTYLE:OFF"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="CHECKSTYLE:ON"/>
+    </profile>
+</profiles>

--- a/cyberark-vault/pom.xml
+++ b/cyberark-vault/pom.xml
@@ -31,10 +31,10 @@
         <quarkus.platform.version>3.38.0</quarkus.platform.version>
         <camel-quarkus.platform.version>3.39.0-SNAPSHOT</camel-quarkus.platform.version>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/cyberark-vault/pom.xml
+++ b/cyberark-vault/pom.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-quarkus-examples-cyberark-vault</artifactId>
+    <groupId>org.apache.camel.quarkus.examples</groupId>
+    <version>3.38.0-SNAPSHOT</version>
+
+    <name>Camel Quarkus :: Examples :: CyberArk Vault</name>
+    <description>Camel Quarkus Example :: CyberArk Vault</description>
+
+    <properties>
+        <quarkus.platform.version>3.38.0</quarkus.platform.version>
+        <camel-quarkus.platform.version>3.39.0-SNAPSHOT</camel-quarkus.platform.version>
+
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+
+        <smallrye-certificate-generator-junit5.version>0.9.3</smallrye-certificate-generator-junit5.version>
+        <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>
+        <impsort-maven-plugin.version>1.13.0</impsort-maven-plugin.version>
+        <license-maven-plugin.version>5.1.1</license-maven-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import BOM -->
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>${camel-quarkus.platform.group-id}</groupId>
+                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
+                <version>${camel-quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-cyberark-vault</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-direct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-timer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.certs</groupId>
+            <artifactId>smallrye-certificate-generator-junit5</artifactId>
+            <version>${smallrye-certificate-generator-junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>net.revelc.code.formatter</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <version>${formatter-maven-plugin.version}</version>
+                    <configuration>
+                        <configFile>${maven.multiModuleProjectDirectory}/eclipse-formatter-config.xml</configFile>
+                        <lineEnding>LF</lineEnding>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>net.revelc.code</groupId>
+                    <artifactId>impsort-maven-plugin</artifactId>
+                    <version>${impsort-maven-plugin.version}</version>
+                    <configuration>
+                        <groups>java.,javax.,org.w3c.,org.xml.,junit.</groups>
+                        <removeUnused>true</removeUnused>
+                        <staticAfter>true</staticAfter>
+                        <staticGroups>java.,javax.,org.w3c.,org.xml.,junit.</staticGroups>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <showDeprecation>true</showDeprecation>
+                        <showWarnings>true</showWarnings>
+                        <compilerArgs>
+                            <arg>-Xlint:unchecked</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <failIfNoTests>false</failIfNoTests>
+                        <systemPropertyVariables>
+                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>${quarkus.platform.group-id}</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${quarkus.platform.version}</version>
+                    <extensions>true</extensions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>${license-maven-plugin.version}</version>
+                    <configuration>
+                        <failIfUnknown>true</failIfUnknown>
+                        <header>${maven.multiModuleProjectDirectory}/header.txt</header>
+                        <excludes>
+                            <exclude>**/*.adoc</exclude>
+                            <exclude>**/*.txt</exclude>
+                            <exclude>**/*.conf</exclude>
+                            <exclude>**/LICENSE.txt</exclude>
+                            <exclude>**/LICENSE</exclude>
+                            <exclude>**/NOTICE.txt</exclude>
+                            <exclude>**/NOTICE</exclude>
+                            <exclude>**/README</exclude>
+                            <exclude>**/pom.xml.versionsBackup</exclude>
+                        </excludes>
+                        <mapping>
+                            <java>SLASHSTAR_STYLE</java>
+                            <properties>CAMEL_PROPERTIES_STYLE</properties>
+                            <kt>SLASHSTAR_STYLE</kt>
+                        </mapping>
+                        <headerDefinitions>
+                            <headerDefinition>${maven.multiModuleProjectDirectory}/license-properties-headerdefinition.xml</headerDefinition>
+                        </headerDefinitions>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>format</id>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>sort-imports</id>
+                        <goals>
+                            <goal>sort</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>license-format</id>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>skip-testcontainers-tests</id>
+            <activation>
+                <property>
+                    <name>skip-testcontainers-tests</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <quarkus.native.enabled>${quarkus.native.enabled}</quarkus.native.enabled>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/cyberark-vault/src/main/java/org/acme/cyberark/vault/CyberarkVaultResource.java
+++ b/cyberark-vault/src/main/java/org/acme/cyberark/vault/CyberarkVaultResource.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme.cyberark.vault;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import org.apache.camel.ProducerTemplate;
+
+@Path("/cyberark-vault")
+@ApplicationScoped
+public class CyberarkVaultResource {
+
+    @Inject
+    ProducerTemplate producerTemplate;
+
+    @Path("/createSecret")
+    @POST
+    public void createSecret(String body) {
+        producerTemplate.requestBody("direct:createSecret", body, String.class);
+    }
+
+    @Path("/getSecret")
+    @GET
+    public String getSecret() {
+        return producerTemplate.requestBody("direct:getSecret", "", String.class);
+    }
+
+    @Path("/propertyPlaceholder")
+    @GET
+    public String propertyPlaceholder() {
+        return producerTemplate.requestBody("direct:propertyPlaceholder", "", String.class);
+    }
+}

--- a/cyberark-vault/src/main/java/org/acme/cyberark/vault/CyberarkVaultRoutes.java
+++ b/cyberark-vault/src/main/java/org/acme/cyberark/vault/CyberarkVaultRoutes.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme.cyberark.vault;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.PropertiesComponent;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class CyberarkVaultRoutes extends RouteBuilder {
+
+    @ConfigProperty(name = "conjur.url")
+    String url;
+    @ConfigProperty(name = "conjur.account")
+    String account;
+    @ConfigProperty(name = "conjur.writer.username")
+    String writerUsername;
+    @ConfigProperty(name = "conjur.writer.apiKey")
+    String writerApiKey;
+    @ConfigProperty(name = "conjur.reader.username")
+    String readerUsername;
+    @ConfigProperty(name = "conjur.reader.apiKey")
+    String readerApiKey;
+
+    @Override
+    public void configure() throws Exception {
+
+        from("direct:createSecret")
+                .toF("cyberark-vault:secret?operation=createSecret&secretId=BotApp/secretVar&url=%s&account=%s&username=%s&apiKey=%s",
+                        url, account, writerUsername, writerApiKey)
+                .log("Secret created/updated");
+
+        from("direct:getSecret")
+                .toF("cyberark-vault:secret?secretId=BotApp/secretVar&url=%s&account=%s&username=%s&apiKey=%s",
+                        url, account, readerUsername, readerApiKey)
+                .log("Retrieved secret: ${body}");
+
+        from("direct:propertyPlaceholder")
+                .process(exchange -> {
+                    PropertiesComponent component = exchange.getContext().getPropertiesComponent();
+                    component.resolveProperty("cyberark:BotApp/secretVar").ifPresent(value -> {
+                        exchange.getMessage().setBody(value);
+                    });
+                });
+
+        from("timer:readSecret?period=5000")
+                .autoStartup("{{timer.enabled:true}}")
+                .doTry()
+                .process(exchange -> {
+                    PropertiesComponent component = exchange.getContext().getPropertiesComponent();
+                    component.resolveProperty("cyberark:BotApp/secretVar").ifPresent(value -> {
+                        exchange.getMessage().setBody(value);
+                    });
+                })
+                .log("Property placeholder cyberark:BotApp/secretVar resolved to: ${body}")
+                .doCatch(Exception.class)
+                .log("No secret stored yet. Create one with: curl -X POST http://localhost:8080/cyberark-vault/createSecret -d 'my-secret'")
+                .end();
+    }
+}

--- a/cyberark-vault/src/main/resources/application.properties
+++ b/cyberark-vault/src/main/resources/application.properties
@@ -1,0 +1,30 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+conjur.url={{env:CQ_CONJUR_URL}}
+conjur.account={{env:CQ_CONJUR_ACCOUNT}}
+conjur.reader.username={{env:CQ_CONJUR_READ_USER}}
+conjur.reader.apiKey={{env:CQ_CONJUR_READ_USER_API_KEY}}
+conjur.writer.username={{env:CQ_CONJUR_READ_WRITE_USER}}
+conjur.writer.apiKey={{env:CQ_CONJUR_READ_WRITE_USER_API_KEY}}
+
+%test.timer.enabled=false
+
+camel.vault.cyberark.url={{env:CQ_CONJUR_URL}}
+camel.vault.cyberark.account={{env:CQ_CONJUR_ACCOUNT}}
+camel.vault.cyberark.username={{env:CQ_CONJUR_READ_USER}}
+camel.vault.cyberark.apiKey={{env:CQ_CONJUR_READ_USER_API_KEY}}

--- a/cyberark-vault/src/test/java/org/acme/cyberark/vault/CyberarkVaultIT.java
+++ b/cyberark-vault/src/test/java/org/acme/cyberark/vault/CyberarkVaultIT.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme.cyberark.vault;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class CyberarkVaultIT extends CyberarkVaultTest {
+
+}

--- a/cyberark-vault/src/test/java/org/acme/cyberark/vault/CyberarkVaultTest.java
+++ b/cyberark-vault/src/test/java/org/acme/cyberark/vault/CyberarkVaultTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme.cyberark.vault;
+
+import java.util.UUID;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "nginx", formats = { Format.PEM }, cn = "proxy", subjectAlternativeNames = "proxy")
+})
+@QuarkusTest
+@WithTestResource(CyberarkVaultTestResource.class)
+class CyberarkVaultTest {
+    @Test
+    void testCreateGetAndPropertyPlaceholder() {
+        String secret = UUID.randomUUID().toString();
+
+        RestAssured.given()
+                .body(secret)
+                .post("/cyberark-vault/createSecret")
+                .then()
+                .statusCode(204);
+
+        RestAssured
+                .get("/cyberark-vault/getSecret")
+                .then()
+                .statusCode(200)
+                .body(is(secret));
+
+        RestAssured
+                .get("/cyberark-vault/propertyPlaceholder")
+                .then()
+                .statusCode(200)
+                .body(is(secret));
+    }
+}

--- a/cyberark-vault/src/test/java/org/acme/cyberark/vault/CyberarkVaultTestResource.java
+++ b/cyberark-vault/src/test/java/org/acme/cyberark/vault/CyberarkVaultTestResource.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.acme.cyberark.vault;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.junit.jupiter.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+public class CyberarkVaultTestResource implements QuarkusTestResourceLifecycleManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CyberarkVaultTestResource.class);
+    private static final String POSTGRES_PASSWORD = "SuperSecretPg";
+    private static final String CONJUR_DATA_KEY = "changeitchangeitchangeitchangeitchangeitIhc=";
+    private static final String CONJUR_ACCOUNT = "myConjurAccount";
+    private static final String POSTGRES_IMAGE = "mirror.gcr.io/postgres:17.5";
+    private static final String CONJUR_IMAGE = "mirror.gcr.io/cyberark/conjur:1.24.0";
+    private static final String CONJUR_CLI_IMAGE = "mirror.gcr.io/cyberark/conjur-cli:9";
+    private static final String NGINX_IMAGE = "mirror.gcr.io/nginx:1.30.3-alpine3.23-perl";
+    private static final int CONJUR_PORT = 80;
+    private static final int POSTGRES_PORT = 5432;
+    private static final int NGINX_PORT = 443;
+
+    private Network network;
+    private GenericContainer<?> postgresContainer;
+    private GenericContainer<?> conjurContainer;
+    private GenericContainer<?> nginxContainer;
+    private GenericContainer<?> clientContainer;
+
+    @Override
+    public Map<String, String> start() {
+        final Map<String, String> result = new LinkedHashMap<>();
+
+        List<String> missingExternalProperties = Stream
+                .of("CQ_CONJUR_URL", "CQ_CONJUR_ACCOUNT", "CQ_CONJUR_READ_USER", "CQ_CONJUR_READ_USER_API_KEY",
+                        "CQ_CONJUR_READ_WRITE_USER", "CQ_CONJUR_READ_WRITE_USER_API_KEY")
+                .filter(prop -> {
+                    String value = System.getenv(prop);
+                    return value == null || value.isEmpty();
+                })
+                .toList();
+        if (missingExternalProperties.isEmpty()) {
+            LOGGER.info("Using real CyberArk Conjur backend");
+            result.put("quarkus.http.port", "0");
+            result.put("quarkus.http.test-port", "0");
+            return result;
+        }
+
+        if (missingExternalProperties.size() < 6) {
+            throw new RuntimeException(
+                    "Several environmental properties are missing (you have to provide either all of them or none). "
+                            + "Missing properties are: " + String.join(",", missingExternalProperties));
+        }
+        LOGGER.info("Using testcontainers mock backend");
+
+        try {
+            network = Network.newNetwork();
+            startPostgresContainer();
+            startConjurContainer();
+            startNginxContainer();
+            startClientContainer();
+            initializeConjur(result);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to start Conjur test environment", e);
+        }
+
+        String conjurUrl = "http://localhost:" + conjurContainer.getMappedPort(CONJUR_PORT);
+
+        result.put("conjur.account", CONJUR_ACCOUNT);
+        result.put("conjur.url", conjurUrl);
+
+        result.put("camel.vault.cyberark.url", conjurUrl);
+        result.put("camel.vault.cyberark.account", CONJUR_ACCOUNT);
+        result.put("camel.vault.cyberark.username", result.get("conjur.reader.username"));
+        result.put("camel.vault.cyberark.apiKey", result.get("conjur.reader.apiKey"));
+
+        return result;
+    }
+
+    private void startPostgresContainer() {
+        LOGGER.info("Starting PostgreSQL container...");
+
+        postgresContainer = new GenericContainer<>(DockerImageName.parse(POSTGRES_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases("database")
+                .withExposedPorts(POSTGRES_PORT)
+                .withEnv("POSTGRES_USER", "postgres")
+                .withEnv("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+                .withEnv("POSTGRES_DB", "postgres")
+                .withLogConsumer(frame -> LOGGER.debug("[POSTGRESQL] {}", frame.getUtf8StringWithoutLineEnding()));
+
+        postgresContainer.start();
+        LOGGER.info("PostgreSQL container started");
+    }
+
+    private void startConjurContainer() {
+        LOGGER.info("Starting Conjur container...");
+
+        String databaseUrl = String.format("postgres://postgres:%s@database/postgres", POSTGRES_PASSWORD);
+
+        conjurContainer = new GenericContainer<>(DockerImageName.parse(CONJUR_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases("conjur")
+                .withCommand("server")
+                .withEnv("DATABASE_URL", databaseUrl)
+                .withEnv("CONJUR_DATA_KEY", CONJUR_DATA_KEY)
+                .withEnv("CONJUR_AUTHENTICATORS", "")
+                .withEnv("CONJUR_TELEMETRY_ENABLED", "false")
+                .withEnv("CONJUR_API_RESOURCE_LIST_LIMIT_MAX", "5000")
+                .withExposedPorts(CONJUR_PORT)
+                .withLogConsumer(frame -> LOGGER.debug("[CONJUR] {}", frame.getUtf8StringWithoutLineEnding()))
+                .waitingFor(Wait.forLogMessage(".*Listening on http.*", 1)
+                        .withStartupTimeout(Duration.ofMinutes(2)))
+                .dependsOn(postgresContainer);
+
+        conjurContainer.start();
+        LOGGER.info("Conjur container started on port {}", conjurContainer.getMappedPort(CONJUR_PORT));
+    }
+
+    private void startNginxContainer() throws Exception {
+        LOGGER.info("Starting Nginx proxy container...");
+
+        Path certsDir = Paths.get("target/certs");
+        Path nginxCert = certsDir.resolve("nginx.crt");
+        Path nginxKey = certsDir.resolve("nginx.key");
+
+        if (!Files.exists(nginxCert) || !Files.exists(nginxKey)) {
+            throw new RuntimeException("SSL certificates not found in target/certs.");
+        }
+
+        nginxContainer = new GenericContainer<>(DockerImageName.parse(NGINX_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases("proxy")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("conf/default.conf"),
+                        "/etc/nginx/conf.d/default.conf")
+                .withCopyFileToContainer(MountableFile.forHostPath(nginxCert), "/etc/nginx/tls/nginx.crt")
+                .withCopyFileToContainer(MountableFile.forHostPath(nginxKey), "/etc/nginx/tls/nginx.key")
+                .withExposedPorts(NGINX_PORT)
+                .withLogConsumer(frame -> LOGGER.debug("[NGINX] {}", frame.getUtf8StringWithoutLineEnding()))
+                .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(1)))
+                .dependsOn(conjurContainer);
+
+        nginxContainer.start();
+        LOGGER.info("Nginx proxy container started on port {}", nginxContainer.getMappedPort(NGINX_PORT));
+    }
+
+    private void startClientContainer() {
+        LOGGER.info("Starting Conjur CLI client container...");
+
+        clientContainer = new GenericContainer<>(DockerImageName.parse(CONJUR_CLI_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases("client")
+                .withCreateContainerCmdModifier(cmd -> {
+                    cmd.withEntrypoint("sleep");
+                })
+                .withCommand("infinity")
+                .withCopyFileToContainer(
+                        MountableFile.forClasspathResource("conf/policy/BotApp.yml"),
+                        "/policy/BotApp.yml")
+                .withLogConsumer(frame -> LOGGER.debug("[CLIENT] {}", frame.getUtf8StringWithoutLineEnding()))
+                .withStartupTimeout(Duration.ofSeconds(5))
+                .dependsOn(nginxContainer);
+
+        clientContainer.start();
+        LOGGER.info("Conjur CLI client container started");
+    }
+
+    private void initializeConjur(Map<String, String> result) throws Exception {
+        LOGGER.info("Initializing Conjur account...");
+
+        Container.ExecResult accountResult = conjurContainer.execInContainer(
+                "conjurctl", "account", "create", CONJUR_ACCOUNT);
+        Assertions.assertEquals(0, accountResult.getExitCode(),
+                "Creation of account failed with: " + accountResult.getStderr());
+
+        String adminKey = accountResult.getStdout().lines()
+                .filter(line -> line.contains("API key"))
+                .map(line -> line.replaceAll(".*API key for admin: ", "").trim())
+                .findFirst()
+                .orElseGet(() -> {
+                    String[] tokens = accountResult.getStdout().split("\\s");
+                    return tokens[tokens.length - 1];
+                });
+
+        Container.ExecResult er;
+
+        er = clientContainer.execInContainer(
+                "conjur", "init", "oss", "-u", "https://proxy", "-a", CONJUR_ACCOUNT, "--self-signed");
+        Assertions.assertEquals(0, er.getExitCode(), "Client init failed with: " + er.getStderr());
+
+        er = clientContainer.execInContainer(
+                "conjur", "login", "-i", "admin", "-p", adminKey);
+        Assertions.assertEquals(0, er.getExitCode(), "Client login failed with: " + er.getStderr());
+
+        er = clientContainer.execInContainer(
+                "conjur", "policy", "load", "-b", "root", "-f", "/policy/BotApp.yml");
+        Assertions.assertEquals(0, er.getExitCode(), "Policy load failed with: " + er.getStderr());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(er.getStdout());
+
+        result.put("conjur.reader.username", "host/BotApp/myDemoApp");
+        result.put("conjur.reader.apiKey",
+                jsonNode.get("created_roles").get(CONJUR_ACCOUNT + ":host:BotApp/myDemoApp").get("api_key").textValue());
+        result.put("conjur.writer.username", "user/Dave@BotApp");
+        result.put("conjur.writer.apiKey",
+                jsonNode.get("created_roles").get(CONJUR_ACCOUNT + ":user:Dave@BotApp").get("api_key").textValue());
+
+        clientContainer.execInContainer("conjur", "logout");
+
+        LOGGER.info("Conjur initialization complete");
+    }
+
+    @Override
+    public void stop() {
+        try {
+            if (clientContainer != null) {
+                clientContainer.stop();
+            }
+            if (nginxContainer != null) {
+                nginxContainer.stop();
+            }
+            if (conjurContainer != null) {
+                conjurContainer.stop();
+            }
+            if (postgresContainer != null) {
+                postgresContainer.stop();
+            }
+            if (network != null) {
+                network.close();
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Error during cleanup", e);
+        }
+    }
+}

--- a/cyberark-vault/src/test/resources/conf/default.conf
+++ b/cyberark-vault/src/test/resources/conf/default.conf
@@ -1,0 +1,12 @@
+server {
+    listen              443 ssl;
+    server_name         proxy;
+    access_log          /var/log/nginx/access.log;
+
+    ssl_certificate     /etc/nginx/tls/nginx.crt;
+    ssl_certificate_key /etc/nginx/tls/nginx.key;
+
+    location / {
+      proxy_pass http://conjur;
+    }
+}

--- a/cyberark-vault/src/test/resources/conf/policy/BotApp.yml
+++ b/cyberark-vault/src/test/resources/conf/policy/BotApp.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- !policy
+  id: BotApp
+  body:
+  - !user Dave
+  - !host myDemoApp
+  - !variable secretVar
+  - !permit
+    role: !user Dave
+    privileges: [read, update, execute]
+    resource: !variable secretVar
+  - !permit
+    role: !host myDemoApp
+    privileges: [read, execute]
+    resource: !variable secretVar

--- a/cyberark-vault/start-conjur.sh
+++ b/cyberark-vault/start-conjur.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONJUR_ACCOUNT="myConjurAccount"
+CONJUR_PORT="${CONJUR_PORT:-9080}"
+COMPOSE_ARGS="-f $SCRIPT_DIR/docker-compose.yml -p cyberark-vault"
+
+# --- stop mode ---
+if [[ "${1:-}" == "stop" ]]; then
+    docker compose $COMPOSE_ARGS down -v
+    echo "Conjur environment stopped."
+    exit 0
+fi
+
+# --- prerequisites ---
+for cmd in docker curl jq; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: '$cmd' is required but not installed." >&2
+        exit 1
+    fi
+done
+
+# --- clean start (wipe previous volumes so account/policy are fresh) ---
+docker compose $COMPOSE_ARGS down -v 2>/dev/null || true
+
+echo "Starting Conjur environment..."
+CONJUR_PORT="$CONJUR_PORT" docker compose $COMPOSE_ARGS up -d
+
+# --- wait for Conjur to accept connections ---
+echo "Waiting for Conjur to be ready..."
+for i in $(seq 1 60); do
+    if curl -so /dev/null "http://localhost:$CONJUR_PORT/" 2>/dev/null; then
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        echo "Error: Conjur did not become ready within 120 s." >&2
+        exit 1
+    fi
+    sleep 2
+done
+echo "Conjur is ready."
+
+# --- create account ---
+echo "Creating account '$CONJUR_ACCOUNT'..."
+ACCOUNT_OUTPUT=$(docker compose $COMPOSE_ARGS exec -T conjur \
+    conjurctl account create "$CONJUR_ACCOUNT" 2>&1)
+ADMIN_KEY=$(echo "$ACCOUNT_OUTPUT" | tr -s '[:space:]' '\n' | tail -1)
+
+if [ -z "$ADMIN_KEY" ]; then
+    echo "Error: failed to extract admin API key." >&2
+    echo "$ACCOUNT_OUTPUT" >&2
+    exit 1
+fi
+
+# --- authenticate as admin ---
+TOKEN=$(curl -sf -X POST \
+    "http://localhost:$CONJUR_PORT/authn/$CONJUR_ACCOUNT/admin/authenticate" \
+    -d "$ADMIN_KEY" | base64 | tr -d '\n')
+
+# --- load policy ---
+echo "Loading BotApp policy..."
+POLICY_FILE="$SCRIPT_DIR/src/test/resources/conf/policy/BotApp.yml"
+POLICY_RESPONSE=$(curl -sf -X PUT \
+    "http://localhost:$CONJUR_PORT/policies/$CONJUR_ACCOUNT/policy/root" \
+    -H "Authorization: Token token=\"$TOKEN\"" \
+    -H "Content-Type: application/x-yaml" \
+    --data-binary @"$POLICY_FILE")
+
+READ_API_KEY=$(echo "$POLICY_RESPONSE" | jq -r \
+    ".created_roles[\"$CONJUR_ACCOUNT:host:BotApp/myDemoApp\"].api_key")
+WRITE_API_KEY=$(echo "$POLICY_RESPONSE" | jq -r \
+    ".created_roles[\"$CONJUR_ACCOUNT:user:Dave@BotApp\"].api_key")
+
+if [ "$READ_API_KEY" = "null" ] || [ "$WRITE_API_KEY" = "null" ]; then
+    echo "Error: failed to extract API keys from policy response." >&2
+    echo "$POLICY_RESPONSE" >&2
+    exit 1
+fi
+
+# --- output ---
+cat <<EOF
+
+Conjur environment is ready!
+
+Run these commands, then start the example:
+
+  export CQ_CONJUR_URL=http://localhost:$CONJUR_PORT
+  export CQ_CONJUR_ACCOUNT=$CONJUR_ACCOUNT
+  export CQ_CONJUR_READ_USER=host/BotApp/myDemoApp
+  export CQ_CONJUR_READ_USER_API_KEY=$READ_API_KEY
+  export CQ_CONJUR_READ_WRITE_USER=user/Dave@BotApp
+  export CQ_CONJUR_READ_WRITE_USER_API_KEY=$WRITE_API_KEY
+
+  mvn clean compile quarkus:dev -f $SCRIPT_DIR/pom.xml
+
+To stop:  $0 stop
+EOF

--- a/docs/modules/ROOT/attachments/examples.json
+++ b/docs/modules/ROOT/attachments/examples.json
@@ -25,6 +25,11 @@
     "link": "https://github.com/apache/camel-quarkus-examples/tree/main/timer-log-main"
   },
   {
+    "title": "CyberArk Vault",
+    "description": "Shows how to retrieve secrets from CyberArk Vault via property placeholders with a local Conjur container",
+    "link": "https://github.com/apache/camel-quarkus-examples/tree/main/cyberark-vault"
+  },
+  {
     "title": "Deploying a Camel Route in AWS Lambda ",
     "description": "Shows how to deploy a Camel Quarkus route as an AWS Lambda function",
     "link": "https://github.com/apache/camel-quarkus-examples/tree/main/aws-lambda"

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <module>aws2-s3</module>
         <module>cluster-leader-election</module>
         <module>cxf-soap</module>
+        <module>cyberark-vault</module>
         <module>data-extract-langchain4j</module>
         <module>fhir</module>
         <module>file-bindy-ftp</module>


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/8897

- Adds a new `cyberark-vault` example demonstrating secret retrieval/creation from CyberArk
  Vault (Conjur) using the Camel CyberArk component
- Includes full testcontainers setup (PostgreSQL + Conjur server + Nginx TLS proxy + CLI 
client) with fallback to external Conjur via environment variables
- Includes a `start-conjur.sh` helper script and `docker-compose.yml` for local development