### PR TITLE
Upgrade to Quarkus Platform 3.33.3

### DIFF
--- a/amqp/pom.xml
+++ b/amqp/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: AMQP</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/artemis-elasticsearch/pom.xml
+++ b/artemis-elasticsearch/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Artemis ElasticSearch</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -27,7 +27,7 @@
     <description>Camel Quarkus Example :: Deploying a Camel Route in AWS Lambda</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/aws-lambda/src/main/docker/Dockerfile.jvm
+++ b/aws-lambda/src/main/docker/Dockerfile.jvm
@@ -23,11 +23,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/aws-lambda-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/temp-quarkus-project-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/aws-lambda-jvm
+# docker run -i --rm -p 8080:8080 quarkus/temp-quarkus-project-jvm
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -36,7 +36,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 quarkus/aws-lambda-jvm
+# docker run -i --rm -p 8080:8080 quarkus/temp-quarkus-project-jvm
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/aws-lambda/src/main/docker/Dockerfile.legacy-jar
+++ b/aws-lambda/src/main/docker/Dockerfile.legacy-jar
@@ -23,11 +23,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/aws-lambda-legacy-jar .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/temp-quarkus-project-legacy-jar .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/aws-lambda-legacy-jar
+# docker run -i --rm -p 8080:8080 quarkus/temp-quarkus-project-legacy-jar
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -36,7 +36,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 quarkus/aws-lambda-legacy-jar
+# docker run -i --rm -p 8080:8080 quarkus/temp-quarkus-project-legacy-jar
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/aws-lambda/src/main/docker/Dockerfile.native
+++ b/aws-lambda/src/main/docker/Dockerfile.native
@@ -23,11 +23,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/aws-lambda .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/temp-quarkus-project .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/aws-lambda
+# docker run -i --rm -p 8080:8080 quarkus/temp-quarkus-project
 #
 # The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.

--- a/aws-lambda/src/main/docker/Dockerfile.native-micro
+++ b/aws-lambda/src/main/docker/Dockerfile.native-micro
@@ -26,11 +26,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-micro -t quarkus/aws-lambda .
+# docker build -f src/main/docker/Dockerfile.native-micro -t quarkus/temp-quarkus-project .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/aws-lambda
+# docker run -i --rm -p 8080:8080 quarkus/temp-quarkus-project
 #
 # The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.

--- a/aws2-s3/pom.xml
+++ b/aws2-s3/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Upload a file to an AWS S3 bucket</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -29,7 +29,7 @@
     <description>Camel Quarkus Example :: Cluster leader election</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/cxf-soap/pom.xml
+++ b/cxf-soap/pom.xml
@@ -29,7 +29,7 @@
     <description>Camel Quarkus Example :: CXF SOAP</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/data-extract-langchain4j/pom.xml
+++ b/data-extract-langchain4j/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
 
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/fhir/pom.xml
+++ b/fhir/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: FHIR</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: JMS JPA</name>
     <description>Camel Quarkus Example :: JMS JPA</description>
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.13.0</quarkiverse-artemis.version>
 

--- a/jpa-idempotent-repository/pom.xml
+++ b/jpa-idempotent-repository/pom.xml
@@ -30,7 +30,7 @@
     <description>Camel Quarkus Example :: JPA Idempotent Repository</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/jta-jpa/pom.xml
+++ b/jta-jpa/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: JTA JPA</name>
     <description>Camel Quarkus Example :: JTA JPA</description>
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Configure XA Transactions and connection pooling</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/netty-custom-correlation/pom.xml
+++ b/netty-custom-correlation/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Communication with Netty over TCP</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
 
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: openapi-contract-first</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/platform-http-security-keycloak/pom.xml
+++ b/platform-http-security-keycloak/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Platform HTTP Security Keycloak</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/quarkus-rest-json/pom.xml
+++ b/quarkus-rest-json/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Quarkus Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -29,7 +29,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.13.0</quarkiverse-artemis.version>
 

--- a/spring-redis/pom.xml
+++ b/spring-redis/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Send and receive messages from Redis</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/variables/pom.xml
+++ b/variables/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Variables</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>

--- a/vertx-websocket-chat/pom.xml
+++ b/vertx-websocket-chat/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Implementing Websocket</description>
 
     <properties>
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>


### PR DESCRIPTION
Note that the `main` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-main` branch pointing at the current Camel Quarkus SNAPSHOT.