### PR TITLE
jdbc-datasource: build the INSERT with statement parameters instead of string interpolation

### DIFF
--- a/jdbc-datasource/README.adoc
+++ b/jdbc-datasource/README.adoc
@@ -66,6 +66,8 @@ Extract, Transform and Load related logs should be output as below:
 2023-11-14 15:12:55,897 INFO  [route17] (Camel (camel-9) thread #9 - timer://insertCamel) -> Loading transformed data in target database
 2023-11-14 15:12:55,904 INFO  [route17] (Camel (camel-9) thread #9 - timer://insertCamel) -> Transforming review for hotel 'Small Hotel'
 2023-11-14 15:12:55,909 INFO  [route17] (Camel (camel-9) thread #9 - timer://insertCamel) -> Loading transformed data in target database
+2023-11-14 15:12:55,915 INFO  [route17] (Camel (camel-9) thread #9 - timer://insertCamel) -> Transforming review for hotel 'O'Brien's Hotel'
+2023-11-14 15:12:55,919 INFO  [route17] (Camel (camel-9) thread #9 - timer://insertCamel) -> Loading transformed data in target database
 ----
 
 === Packaging and running the application

--- a/jdbc-datasource/src/main/java/org/acme/jdbc/JdbcRoutes.java
+++ b/jdbc-datasource/src/main/java/org/acme/jdbc/JdbcRoutes.java
@@ -42,11 +42,16 @@ public class JdbcRoutes extends RouteBuilder {
                     String review = (String) sourceData.get("review");
                     int mappedReview = reviewMapping.getOrDefault(review, 0);
                     sourceData.put("review", mappedReview);
+
+                    exchange.getIn().setHeader("id", sourceData.get("id"));
+                    exchange.getIn().setHeader("hotel_name", sourceData.get("hotel_name"));
+                    exchange.getIn().setHeader("price", sourceData.get("price"));
+                    exchange.getIn().setHeader("review", mappedReview);
                 })
                 .log("-> Transforming review for hotel '${body[hotel_name]}'")
-                .setBody()
-                .simple("INSERT INTO Target (id, hotel_name, price, review) VALUES(${body[id]}, '${body[hotel_name]}', ${body[price]}, ${body[review]})")
-                .to("jdbc:target_db")
+                .setBody(constant(
+                        "INSERT INTO Target (id, hotel_name, price, review) VALUES(:?id, :?hotel_name, :?price, :?review)"))
+                .to("jdbc:target_db?useHeadersAsParameters=true")
                 .log("-> Loading transformed data in target database");
     }
 }

--- a/jdbc-datasource/src/main/java/org/acme/jdbc/JdbcService.java
+++ b/jdbc-datasource/src/main/java/org/acme/jdbc/JdbcService.java
@@ -16,8 +16,10 @@
  */
 package org.acme.jdbc;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import io.agroal.api.AgroalDataSource;
 import io.quarkus.agroal.DataSource;
@@ -39,10 +41,13 @@ public class JdbcService {
 
         StringBuilder sb = new StringBuilder();
 
-        ResultSet rs = targetDb.getConnection().createStatement().executeQuery("SELECT (hotel_name, review) FROM Target");
+        try (Connection connection = targetDb.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("SELECT (hotel_name, review) FROM Target")) {
 
-        while (rs.next()) {
-            sb.append(rs.getString(1));
+            while (rs.next()) {
+                sb.append(rs.getString(1));
+            }
         }
 
         return sb.toString();

--- a/jdbc-datasource/src/test/java/org/acme/jdbc/JdbcTest.java
+++ b/jdbc-datasource/src/test/java/org/acme/jdbc/JdbcTest.java
@@ -38,7 +38,8 @@ public class JdbcTest {
                     .then()
                     .extract().asString();
 
-            return "(\"Grand Hotel\",1)(\"Middle Hotel\",0)(\"Small Hotel\",-1)".equals(hotelReviews);
+            return "(\"Grand Hotel\",1)(\"Middle Hotel\",0)(\"Small Hotel\",-1)(\"O'Brien's Hotel\",0)"
+                    .equals(hotelReviews);
         });
     }
 }

--- a/jdbc-datasource/src/test/resources/init-source-db.sql
+++ b/jdbc-datasource/src/test/resources/init-source-db.sql
@@ -20,4 +20,5 @@ CREATE TABLE IF NOT EXISTS Source (id SERIAL PRIMARY KEY, hotel_name VARCHAR(255
 INSERT INTO Source (id, hotel_name, price, review) VALUES
 (1, 'Grand Hotel', 100, 'best'),
 (2, 'Middle Hotel', 20, 'good'),
-(3, 'Small Hotel', 17, 'worst');
+(3, 'Small Hotel', 17, 'worst'),
+(4, 'O''Brien''s Hotel', 90, 'good');


### PR DESCRIPTION
The ETL route built its INSERT by interpolating row values into the statement text:

```java
.simple("INSERT INTO Target (id, hotel_name, price, review) VALUES(${body[id]}, '${body[hotel_name]}', ${body[price]}, ${body[review]})")
```

The values come from the source database rather than an end user, so this example isn't exploitable as shipped. But it's the canonical SQL injection shape, in the one example a reader consults for "how do I do JDBC with Camel" — and readers will carry it into routes where the data *is* user-supplied.

It also breaks on ordinary data. A hotel name containing an apostrophe produces `syntax error at or near ...` and the row is silently dropped.

### Changes

- **`JdbcRoutes`** — switch to `useHeadersAsParameters=true` with `:?name` placeholders, so the values are bound as JDBC statement parameters. The statement text is now static, so `setBody()` takes a `constant()` rather than a Simple expression.
- **`JdbcService`** — wrap the JDBC access in try-with-resources. It previously leaked a pooled connection per request, which would exhaust the pool under load. The query itself is a hardcoded constant, so this is hygiene rather than a vulnerability — but it's hygiene in a file people copy.
- **Seed data / test** — add `O'Brien's Hotel` as a regression test. It fails on the old route and passes on the new one.

### Verification

Seeding the source database with hostile values and running the route:

| Source value | Before | After |
|---|---|---|
| `O'Brien's Hotel` | `syntax error at or near "Brien"`, row silently dropped | stored correctly |
| `X', 0, 0); CREATE TABLE pwned AS SELECT 1 AS owned; --` | `pwned` table created in `target_db` | stored verbatim as data |

Postgres allows multiple statements in a single `Statement.execute`, and `JdbcProducer` uses a plain `Statement` unless `useHeadersAsParameters` is set — so the second row really did execute attacker-chosen DDL against the target database before this change.

`mvn clean install` passes for the module, including the formatter, import-order and license header checks. The native build has been run locally.

_Claude Code on behalf of James Netherton_