### PR TITLE
Document Jolokia remote access config for the observability example

### DIFF
--- a/observability/README.adoc
+++ b/observability/README.adoc
@@ -319,7 +319,15 @@ $ hawtio --port 8085
 When this example project is run in dev mode, it will be discoverable from Hawtio via the 'Discover' tab.
 When running the application from the runnable JAR or native binary, you'll need to choose 'Add Connection' from the 'Remote' tab and add a connection for http://localhost:8778/jolokia/.
 
-When deploying to Kubernetes or Openshift, you can use https://github.com/hawtio/hawtio-online[Hawtio Online]. The `camel-quarkus-jolokia` extension will automatically configure the application to be discoverable from the Hawtio Online console.
+When deploying to Kubernetes or Openshift, you can use https://github.com/hawtio/hawtio-online[Hawtio Online]. The `camel-quarkus-jolokia` extension configures SSL client authentication automatically, but you must also uncomment the following properties in `application.properties`.
+
+[source,properties]
+----
+quarkus.camel.jolokia.server.host=0.0.0.0
+quarkus.camel.jolokia.remote-access-allowed=true
+----
+
+The Jolokia agent binds to `localhost` by default, which is unreachable from outside the pod, and the default restrictor rejects requests from non-loopback addresses.
 
 === Package and run the application
 

--- a/observability/src/main/resources/application.properties
+++ b/observability/src/main/resources/application.properties
@@ -47,3 +47,7 @@ greeting-provider-app.service.port = ${quarkus.http.port}
 
 # Optional hawtio-online support
 quarkus.camel.jolokia.kubernetes.client-principal=cn=hawtio-online.hawtio.svc
+# Uncomment when deploying to Kubernetes or OpenShift. The Jolokia agent binds to localhost by default,
+# which is unreachable from outside the pod, and the default restrictor rejects non-loopback requests.
+# quarkus.camel.jolokia.server.host=0.0.0.0
+# quarkus.camel.jolokia.remote-access-allowed=true


### PR DESCRIPTION
Companion to https://github.com/apache/camel-quarkus/pull/8944

That PR hardens the Jolokia extension defaults: the agent now binds to `localhost` in prod mode, and the default restrictor rejects requests from non-loopback addresses. Both are required for hawtio-online to reach the agent on Kubernetes, since a Service DNATs to the pod IP rather than proxying through the pod's loopback.

- `application.properties`: added `quarkus.camel.jolokia.server.host` and `quarkus.camel.jolokia.remote-access-allowed`, commented out so local runs keep the secure defaults.
- `README.adoc`: the Jolokia & Hawtio section claimed the extension "will automatically configure the application to be discoverable from the Hawtio Online console", which is no longer accurate. Replaced with the config that is now needed.

Docs and comments only, no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)